### PR TITLE
Changed Text-lg to text-sm so page title matches

### DIFF
--- a/src/app/[siteKey]/[locale]/events/page.tsx
+++ b/src/app/[siteKey]/[locale]/events/page.tsx
@@ -36,7 +36,7 @@ const EventsPage = async ({ params }: { params: Promise<Params> }) => {
 
   return (
     <TwoColumnLayout>
-      <ColumnLeft className="text-lg text-secondary">
+      <ColumnLeft className="text-sm text-secondary">
         <p className="pb-8 text-primary">{pageTitle}</p>
       </ColumnLeft>
       <ColumnRight>


### PR DESCRIPTION
was set to tet-lg on the events listing instead of text-sm