### PR TITLE
Set image cache TTL to one year

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,7 @@ const withNextIntl = createNextIntlPlugin("./src/lib/i18n/request.ts");
 const nextConfig: NextConfig = {
   transpilePackages: ["lucide-react", "@venuecms/sdk"],
   images: {
+    minimumCacheTTL: 31536000,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
Configure `images.minimumCacheTTL` to 31536000 seconds (1 year) for Next