### PR TITLE
feat(search): use /search/all endpoint for unified results

### DIFF
--- a/src/app/[siteKey]/[locale]/layout.tsx
+++ b/src/app/[siteKey]/[locale]/layout.tsx
@@ -32,7 +32,7 @@ const LayoutContent = async ({
     <NextIntlClientProvider locale={locale} messages={messages}>
       <QueryProvider>
         <VenueProvider siteKey={siteKey}>
-          <SearchProvider>
+          <SearchProvider siteKey={siteKey}>
             <Suspense fallback={null}>
               <NavigationProgress />
             </Suspense>

--- a/src/app/[siteKey]/[locale]/layout.tsx
+++ b/src/app/[siteKey]/[locale]/layout.tsx
@@ -31,7 +31,7 @@ const LayoutContent = async ({
     <NextIntlClientProvider locale={locale} messages={messages}>
       <QueryProvider>
         <VenueProvider siteKey={siteKey}>
-          <SearchProvider>
+          <SearchProvider siteKey={siteKey}>
             <Suspense fallback={null}>
               <NavigationProgress />
             </Suspense>

--- a/src/components/Search/provider.tsx
+++ b/src/components/Search/provider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { SearchSiteResponse, searchSite } from "@venuecms/sdk";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { LocalizedContent, MediaItem } from "@venuecms/sdk";
 import {
   Dispatch,
   PropsWithChildren,
@@ -15,32 +15,43 @@ import {
 } from "react";
 import { useDebounce } from "use-debounce";
 
-// Define the shape of the context value
+export type SearchAllType = "event" | "page" | "profile" | "product";
+
+export type SearchAllRecord = {
+  id: string;
+  type: SearchAllType;
+  slug: string;
+  siteId: string;
+  image?: MediaItem | null;
+  localizedContent: Array<LocalizedContent>;
+  similarity: number;
+};
+
+export type SearchAllResponse = {
+  records: Array<SearchAllRecord>;
+};
+
 interface SearchQueryContextType {
   query: string;
   setQuery: Dispatch<SetStateAction<string>>;
   reset: () => void;
   isActive: boolean;
   setActive: Dispatch<SetStateAction<boolean>>;
+  siteKey: string;
 }
 
-// Create the context with a default value (or throw error in hook if not provided)
 const SearchQueryContext = createContext<SearchQueryContextType | undefined>(
   undefined,
 );
 
-// Define the structure for empty results, useful as initialData for useQuery
-export const emptyResults: SearchSiteResponse = {
-  events: [] as SearchSiteResponse["events"],
-  profiles: [] as SearchSiteResponse["profiles"],
-  pages: [] as SearchSiteResponse["pages"],
-  products: [] as SearchSiteResponse["products"],
+export const emptyResults: SearchAllResponse = {
+  records: [],
 };
 
-/**
- * Provides the search query state (query string and setter) to its children.
- */
-export const SearchProvider = ({ children }: PropsWithChildren) => {
+export const SearchProvider = ({
+  siteKey,
+  children,
+}: PropsWithChildren<{ siteKey: string }>) => {
   const [query, setQuery] = useState<string>("");
   const [isActive, setActive] = useState<boolean>(false);
 
@@ -49,7 +60,6 @@ export const SearchProvider = ({ children }: PropsWithChildren) => {
     setQuery("");
   };
 
-  // Handle Escape key when the search is active
   const handleEsc = useCallback((event: KeyboardEvent) => {
     if (event?.key === "Escape") {
       reset();
@@ -57,7 +67,6 @@ export const SearchProvider = ({ children }: PropsWithChildren) => {
   }, []);
 
   useEffect(() => {
-    // creates an event handler to handle the Esc key
     if (isActive) {
       document.addEventListener("keydown", handleEsc);
     } else {
@@ -69,10 +78,9 @@ export const SearchProvider = ({ children }: PropsWithChildren) => {
     };
   }, [isActive]);
 
-  // Memoize the context value to prevent unnecessary re-renders
   const contextValue = useMemo(
-    () => ({ query, setQuery, isActive, setActive, reset }),
-    [query, isActive],
+    () => ({ query, setQuery, isActive, setActive, reset, siteKey }),
+    [query, isActive, siteKey],
   );
 
   return (
@@ -82,10 +90,6 @@ export const SearchProvider = ({ children }: PropsWithChildren) => {
   );
 };
 
-/**
- * Hook to access the search query and its setter function.
- * Throws an error if used outside of a SearchProvider.
- */
 export const useSearchQuery = (): SearchQueryContextType => {
   const context = useContext(SearchQueryContext);
   if (context === undefined) {
@@ -94,24 +98,25 @@ export const useSearchQuery = (): SearchQueryContextType => {
   return context;
 };
 
-/**
- * Hook to perform the search operation using React Query and Suspense.
- * Consumes the query from SearchQueryContext, handles debouncing,
- * fetching, caching, and provides results and status.
- * Designed to be used in components that will display search results.
- * @param debounceMs - Debounce delay in milliseconds (default: 500).
- * @param minQueryLength - Minimum query length to trigger search (default: 2).
- */
+const fetchSearchAll = async (
+  siteKey: string,
+  query: string,
+): Promise<SearchAllResponse> => {
+  const url = `/api/v2/${encodeURIComponent(siteKey)}/public/search/all?query=${encodeURIComponent(query)}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Search failed: ${response.status}`);
+  }
+  return (await response.json()) as SearchAllResponse;
+};
+
 export const useSearchResults = (
   debounceMs: number = 500,
   minQueryLength: number = 2,
 ) => {
-  // Get the raw query from the context
-  const { query } = useSearchQuery();
-  // Debounce the query value
+  const { query, siteKey } = useSearchQuery();
   const [debouncedQuery] = useDebounce(query, debounceMs);
 
-  // Determine if the debounced query is valid for searching
   const isQueryEnabled = debouncedQuery.trim().length >= minQueryLength;
 
   const {
@@ -119,45 +124,24 @@ export const useSearchResults = (
     isFetching,
     isError,
     error,
-  } = useSuspenseQuery<SearchSiteResponse, Error>({
-    // Use the debounced query in the key
-    queryKey: ["siteSearch", debouncedQuery],
-    queryFn: async (): Promise<SearchSiteResponse> => {
-      // Double-check enablement inside queryFn for safety, though 'enabled' handles this
+  } = useSuspenseQuery<SearchAllResponse, Error>({
+    queryKey: ["siteSearchAll", siteKey, debouncedQuery],
+    queryFn: async (): Promise<SearchAllResponse> => {
       if (!isQueryEnabled) {
-        // Should not happen if 'enabled' is working correctly, but good practice
         return emptyResults;
       }
-      console.log("Fetching search results for:", debouncedQuery); // Added log
-      const { data, error } = await searchSite({ query: debouncedQuery });
-      if (error) {
-        // Throw error to let React Query handle the error state
-        console.error("Search failed:", error); // Log error
-        throw new Error("Search failed");
-      }
-
-      return data ?? emptyResults;
+      return fetchSearchAll(siteKey, debouncedQuery);
     },
-    // Keep data fresh for a short time, cache longer
-    staleTime: 1000 * 60 * 1, // 1 minute (adjusted staleTime slightly for clarity)
-    gcTime: 1000 * 60 * 15, // 15 minutes garbage collection
-    // Use initialData to prevent Suspense triggering on mount with empty query
-    // and provide a stable empty structure when disabled
-    // Keep previous data while fetching new results for smoother UX
-    // keepPreviousData: true,
+    staleTime: 1000 * 60 * 1,
+    gcTime: 1000 * 60 * 15,
   });
 
   return {
-    // The debounced query value used for the search
     debouncedQuery,
-    // The search results, guaranteed to be defined due to initialData
-    results: results as SearchSiteResponse,
-    // Indicates background fetching (useful even with Suspense)
+    results: results as SearchAllResponse,
     isFetching,
-    // Error status and object
     isError,
     error,
-    // Expose whether the current debounced query is long enough to trigger a search
     isQueryEnabled,
   };
 };

--- a/src/components/Search/provider.tsx
+++ b/src/components/Search/provider.tsx
@@ -138,7 +138,7 @@ export const useSearchResults = (
 
   return {
     debouncedQuery,
-    results: results as SearchAllResponse,
+    results,
     isFetching,
     isError,
     error,

--- a/src/components/Search/provider.tsx
+++ b/src/components/Search/provider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { SearchSiteResponse, searchSite } from "@venuecms/sdk-next";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { LocalizedContent, MediaItem } from "@venuecms/sdk-next";
 import {
   Dispatch,
   PropsWithChildren,
@@ -15,32 +15,43 @@ import {
 } from "react";
 import { useDebounce } from "use-debounce";
 
-// Define the shape of the context value
+export type SearchAllType = "event" | "page" | "profile" | "product";
+
+export type SearchAllRecord = {
+  id: string;
+  type: SearchAllType;
+  slug: string;
+  siteId: string;
+  image?: MediaItem | null;
+  localizedContent: Array<LocalizedContent>;
+  similarity: number;
+};
+
+export type SearchAllResponse = {
+  records: Array<SearchAllRecord>;
+};
+
 interface SearchQueryContextType {
   query: string;
   setQuery: Dispatch<SetStateAction<string>>;
   reset: () => void;
   isActive: boolean;
   setActive: Dispatch<SetStateAction<boolean>>;
+  siteKey: string;
 }
 
-// Create the context with a default value (or throw error in hook if not provided)
 const SearchQueryContext = createContext<SearchQueryContextType | undefined>(
   undefined,
 );
 
-// Define the structure for empty results, useful as initialData for useQuery
-export const emptyResults: SearchSiteResponse = {
-  events: [] as SearchSiteResponse["events"],
-  profiles: [] as SearchSiteResponse["profiles"],
-  pages: [] as SearchSiteResponse["pages"],
-  products: [] as SearchSiteResponse["products"],
+export const emptyResults: SearchAllResponse = {
+  records: [],
 };
 
-/**
- * Provides the search query state (query string and setter) to its children.
- */
-export const SearchProvider = ({ children }: PropsWithChildren) => {
+export const SearchProvider = ({
+  siteKey,
+  children,
+}: PropsWithChildren<{ siteKey: string }>) => {
   const [query, setQuery] = useState<string>("");
   const [isActive, setActive] = useState<boolean>(false);
 
@@ -49,7 +60,6 @@ export const SearchProvider = ({ children }: PropsWithChildren) => {
     setQuery("");
   };
 
-  // Handle Escape key when the search is active
   const handleEsc = useCallback((event: KeyboardEvent) => {
     if (event?.key === "Escape") {
       reset();
@@ -57,7 +67,6 @@ export const SearchProvider = ({ children }: PropsWithChildren) => {
   }, []);
 
   useEffect(() => {
-    // creates an event handler to handle the Esc key
     if (isActive) {
       document.addEventListener("keydown", handleEsc);
     } else {
@@ -69,10 +78,9 @@ export const SearchProvider = ({ children }: PropsWithChildren) => {
     };
   }, [isActive]);
 
-  // Memoize the context value to prevent unnecessary re-renders
   const contextValue = useMemo(
-    () => ({ query, setQuery, isActive, setActive, reset }),
-    [query, isActive],
+    () => ({ query, setQuery, isActive, setActive, reset, siteKey }),
+    [query, isActive, siteKey],
   );
 
   return (
@@ -82,10 +90,6 @@ export const SearchProvider = ({ children }: PropsWithChildren) => {
   );
 };
 
-/**
- * Hook to access the search query and its setter function.
- * Throws an error if used outside of a SearchProvider.
- */
 export const useSearchQuery = (): SearchQueryContextType => {
   const context = useContext(SearchQueryContext);
   if (context === undefined) {
@@ -94,24 +98,25 @@ export const useSearchQuery = (): SearchQueryContextType => {
   return context;
 };
 
-/**
- * Hook to perform the search operation using React Query and Suspense.
- * Consumes the query from SearchQueryContext, handles debouncing,
- * fetching, caching, and provides results and status.
- * Designed to be used in components that will display search results.
- * @param debounceMs - Debounce delay in milliseconds (default: 500).
- * @param minQueryLength - Minimum query length to trigger search (default: 2).
- */
+const fetchSearchAll = async (
+  siteKey: string,
+  query: string,
+): Promise<SearchAllResponse> => {
+  const url = `/api/v2/${encodeURIComponent(siteKey)}/public/search/all?query=${encodeURIComponent(query)}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Search failed: ${response.status}`);
+  }
+  return (await response.json()) as SearchAllResponse;
+};
+
 export const useSearchResults = (
   debounceMs: number = 500,
   minQueryLength: number = 2,
 ) => {
-  // Get the raw query from the context
-  const { query } = useSearchQuery();
-  // Debounce the query value
+  const { query, siteKey } = useSearchQuery();
   const [debouncedQuery] = useDebounce(query, debounceMs);
 
-  // Determine if the debounced query is valid for searching
   const isQueryEnabled = debouncedQuery.trim().length >= minQueryLength;
 
   const {
@@ -119,45 +124,24 @@ export const useSearchResults = (
     isFetching,
     isError,
     error,
-  } = useSuspenseQuery<SearchSiteResponse, Error>({
-    // Use the debounced query in the key
-    queryKey: ["siteSearch", debouncedQuery],
-    queryFn: async (): Promise<SearchSiteResponse> => {
-      // Double-check enablement inside queryFn for safety, though 'enabled' handles this
+  } = useSuspenseQuery<SearchAllResponse, Error>({
+    queryKey: ["siteSearchAll", siteKey, debouncedQuery],
+    queryFn: async (): Promise<SearchAllResponse> => {
       if (!isQueryEnabled) {
-        // Should not happen if 'enabled' is working correctly, but good practice
         return emptyResults;
       }
-      console.log("Fetching search results for:", debouncedQuery); // Added log
-      const { data, error } = await searchSite({ query: debouncedQuery });
-      if (error) {
-        // Throw error to let React Query handle the error state
-        console.error("Search failed:", error); // Log error
-        throw new Error("Search failed");
-      }
-
-      return data ?? emptyResults;
+      return fetchSearchAll(siteKey, debouncedQuery);
     },
-    // Keep data fresh for a short time, cache longer
-    staleTime: 1000 * 60 * 1, // 1 minute (adjusted staleTime slightly for clarity)
-    gcTime: 1000 * 60 * 15, // 15 minutes garbage collection
-    // Use initialData to prevent Suspense triggering on mount with empty query
-    // and provide a stable empty structure when disabled
-    // Keep previous data while fetching new results for smoother UX
-    // keepPreviousData: true,
+    staleTime: 1000 * 60 * 1,
+    gcTime: 1000 * 60 * 15,
   });
 
   return {
-    // The debounced query value used for the search
     debouncedQuery,
-    // The search results, guaranteed to be defined due to initialData
-    results: results as SearchSiteResponse,
-    // Indicates background fetching (useful even with Suspense)
+    results: results as SearchAllResponse,
     isFetching,
-    // Error status and object
     isError,
     error,
-    // Expose whether the current debounced query is long enough to trigger a search
     isQueryEnabled,
   };
 };

--- a/src/components/SearchResults/index.test.tsx
+++ b/src/components/SearchResults/index.test.tsx
@@ -1,0 +1,88 @@
+import type { LocalizedContent } from "@venuecms/sdk-next";
+import { NextIntlClientProvider } from "next-intl";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SearchAllRecord, SearchAllResponse } from "../Search/provider";
+
+/**
+ * The point of moving to `/search/all` is that the endpoint returns one ranked
+ * list spanning every record type, and this template lays that single list out
+ * while deriving the per-type filter counts on the client. These tests pin both
+ * halves: every record shows up in one list, and the sidebar counts each type.
+ *
+ * The provider is mocked so the component renders against fixed results without
+ * a network round-trip or a react-query Suspense boundary — the SSR output is
+ * the default `all` filter, which is the state these assertions describe.
+ */
+const { results } = vi.hoisted(() => {
+  const record = (
+    id: string,
+    type: SearchAllRecord["type"],
+    title: string,
+  ): SearchAllRecord => ({
+    id,
+    type,
+    slug: id,
+    siteId: "site-id",
+    image: null,
+    localizedContent: [
+      {
+        siteId: "site-id",
+        locale: "en",
+        title,
+        content: null,
+        shortContent: `${title} blurb`,
+      },
+    ] as Array<LocalizedContent>,
+    similarity: 1,
+  });
+
+  const results: SearchAllResponse = {
+    records: [
+      record("first-event", "event", "First Event"),
+      record("second-event", "event", "Second Event"),
+      record("a-product", "product", "A Product"),
+    ],
+  };
+
+  return { results };
+});
+
+vi.mock("../Search/provider", () => ({
+  useSearchQuery: () => ({ reset: () => {} }),
+  useSearchResults: () => ({ isQueryEnabled: true, results }),
+}));
+
+import { SearchResults } from "./index";
+
+const renderHtml = async (): Promise<string> => {
+  const stream = await renderToReadableStream(
+    <NextIntlClientProvider locale="en" messages={{}}>
+      <SearchResults>fallback</SearchResults>
+    </NextIntlClientProvider>,
+  );
+  await stream.allReady;
+  // React inserts `<!-- -->` markers between adjacent text nodes during SSR;
+  // strip them so assertions can match the visible text.
+  return (await new Response(stream).text()).replaceAll("<!-- -->", "");
+};
+
+describe("SearchResults", () => {
+  it("renders every /search/all record in one unified list", async () => {
+    const html = await renderHtml();
+
+    expect(html).toContain("First Event");
+    expect(html).toContain("Second Event");
+    expect(html).toContain("A Product");
+  });
+
+  it("counts records per type for the filter sidebar", async () => {
+    const html = await renderHtml();
+
+    expect(html).toContain("[ 3 ]"); // all
+    expect(html).toContain("[ 2 ]"); // events
+    expect(html).toContain("[ 1 ]"); // product
+    expect(html).toContain("[ 0 ]"); // profiles and pages have no records
+  });
+});

--- a/src/components/SearchResults/index.tsx
+++ b/src/components/SearchResults/index.tsx
@@ -8,27 +8,37 @@ import {
   ReactNode,
   SetStateAction,
   Suspense,
-  useContext,
   useState,
 } from "react";
 
 import { Link } from "@/lib/i18n";
-import { VenueContext } from "@/lib/utils/VenueProvider";
 
-import { useSearchQuery, useSearchResults } from "../Search/provider";
+import {
+  SearchAllType,
+  useSearchQuery,
+  useSearchResults,
+} from "../Search/provider";
 import { ColumnLeft, ColumnRight, TwoColumnLayout } from "../layout";
 import { Skeleton } from "../ui/Input/Skeleton";
 import { getExcerpt } from "../utils";
 import { ErrorBoundary } from "../utils/ErrorBoundary";
 
-type FilterType = "events" | "profiles" | "pages" | "products";
+type FilterType = SearchAllType | "all";
 
-const filterToPathMap = {
-  events: "events",
-  profiles: "artists",
-  pages: "p",
-  products: "shop",
+const typeToPathMap: Record<SearchAllType, string> = {
+  event: "events",
+  profile: "artists",
+  page: "p",
+  product: "shop",
 };
+
+const filterOptions: Array<{ value: FilterType; label: string }> = [
+  { value: "all", label: "all" },
+  { value: "event", label: "events" },
+  { value: "profile", label: "profiles" },
+  { value: "page", label: "pages" },
+  { value: "product", label: "shop" },
+];
 
 export const SearchResultsLayout = ({ children }: PropsWithChildren) => {
   return (
@@ -45,9 +55,21 @@ export const SearchResults = ({ children }: PropsWithChildren) => {
 
   const { reset } = useSearchQuery();
   const { isQueryEnabled, results } = useSearchResults();
-  const [currentFilter, setCurrentFilter] = useState<FilterType>("events");
+  const [currentFilter, setCurrentFilter] = useState<FilterType>("all");
 
-  const filteredResults = results?.[currentFilter] ?? [];
+  const records = results?.records ?? [];
+  const counts = records.reduce(
+    (acc, record) => {
+      acc[record.type] = (acc[record.type] ?? 0) + 1;
+      return acc;
+    },
+    {} as Record<SearchAllType, number>,
+  );
+
+  const filteredResults =
+    currentFilter === "all"
+      ? records
+      : records.filter((record) => record.type === currentFilter);
 
   return isQueryEnabled ? (
     <TwoColumnLayout>
@@ -55,41 +77,21 @@ export const SearchResults = ({ children }: PropsWithChildren) => {
         <div className="flex flex-col gap-12">
           <div>filter</div>
           <ul className="flex flex-col gap-7">
-            <FilterSelect
-              setFilter={setCurrentFilter}
-              value="events"
-              currentValue={currentFilter}
-              results={results}
-            >
-              events
-            </FilterSelect>
-
-            <FilterSelect
-              setFilter={setCurrentFilter}
-              value="profiles"
-              currentValue={currentFilter}
-              results={results}
-            >
-              profiles
-            </FilterSelect>
-
-            <FilterSelect
-              setFilter={setCurrentFilter}
-              value="pages"
-              currentValue={currentFilter}
-              results={results}
-            >
-              pages
-            </FilterSelect>
-
-            <FilterSelect
-              setFilter={setCurrentFilter}
-              value="products"
-              currentValue={currentFilter}
-              results={results}
-            >
-              shop
-            </FilterSelect>
+            {filterOptions.map((option) => (
+              <FilterSelect
+                key={option.value}
+                setFilter={setCurrentFilter}
+                value={option.value}
+                currentValue={currentFilter}
+                count={
+                  option.value === "all"
+                    ? records.length
+                    : (counts[option.value] ?? 0)
+                }
+              >
+                {option.label}
+              </FilterSelect>
+            ))}
           </ul>
         </div>
       </ColumnLeft>
@@ -104,7 +106,7 @@ export const SearchResults = ({ children }: PropsWithChildren) => {
             return (
               <div className="flex flex-col gap-3" key={result.id}>
                 <Link
-                  href={`/${filterToPathMap[currentFilter]}/${result.slug}`}
+                  href={`/${typeToPathMap[result.type]}/${result.slug}`}
                   onClick={reset}
                 >
                   <div className="text-secondary">{content.title}</div>
@@ -128,19 +130,19 @@ const FilterSelect = ({
   setFilter,
   value,
   currentValue,
-  results = {} as Record<FilterType, Array<any>>,
+  count,
 }: {
   children: ReactNode;
   setFilter: Dispatch<SetStateAction<FilterType>>;
   value: FilterType;
   currentValue: FilterType;
-  results: Record<FilterType, Array<any>>;
+  count: number;
 }) => {
   return (
     <li className="flex gap-8" onClick={() => setFilter(value)}>
       {currentValue === value ? <span>→</span> : null}
       {children}
-      <span>[ {results[value]?.length ?? 0} ]</span>
+      <span>[ {count} ]</span>
     </li>
   );
 };

--- a/src/components/SearchResults/index.tsx
+++ b/src/components/SearchResults/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LocalizedContent, getLocalizedContent } from "@venuecms/sdk-next";
+import { getLocalizedContent } from "@venuecms/sdk-next";
 import { useLocale } from "next-intl";
 import {
   Dispatch,
@@ -8,6 +8,7 @@ import {
   ReactNode,
   SetStateAction,
   Suspense,
+  useMemo,
   useState,
 } from "react";
 
@@ -57,19 +58,27 @@ export const SearchResults = ({ children }: PropsWithChildren) => {
   const { isQueryEnabled, results } = useSearchResults();
   const [currentFilter, setCurrentFilter] = useState<FilterType>("all");
 
-  const records = results?.records ?? [];
-  const counts = records.reduce(
-    (acc, record) => {
-      acc[record.type] = (acc[record.type] ?? 0) + 1;
-      return acc;
-    },
-    {} as Record<SearchAllType, number>,
+  const records = useMemo(() => results?.records ?? [], [results]);
+
+  const counts = useMemo(
+    () =>
+      records.reduce(
+        (acc, record) => {
+          acc[record.type] = (acc[record.type] ?? 0) + 1;
+          return acc;
+        },
+        {} as Record<SearchAllType, number>,
+      ),
+    [records],
   );
 
-  const filteredResults =
-    currentFilter === "all"
-      ? records
-      : records.filter((record) => record.type === currentFilter);
+  const filteredResults = useMemo(
+    () =>
+      currentFilter === "all"
+        ? records
+        : records.filter((record) => record.type === currentFilter),
+    [records, currentFilter],
+  );
 
   return isQueryEnabled ? (
     <TwoColumnLayout>
@@ -100,7 +109,7 @@ export const SearchResults = ({ children }: PropsWithChildren) => {
         <ListContainer>
           {filteredResults.map((result) => {
             const { content } = getLocalizedContent(
-              result.localizedContent as Array<LocalizedContent>,
+              result.localizedContent,
               locale,
             );
             return (


### PR DESCRIPTION
Switches client-side search from `/search` (categorical response) to `/search/all` (unified ranked records list). Search results are now rendered as a single feed with a type filter derived from the record discriminator.

Resolves [VEN-62](/VEN/issues/VEN-62).