### PR TITLE
feat/Update getExcerpt

### DIFF
--- a/src/components/SearchResults/index.tsx
+++ b/src/components/SearchResults/index.tsx
@@ -109,7 +109,7 @@ export const SearchResults = ({ children }: PropsWithChildren) => {
                 >
                   <div className="text-secondary">{content.title}</div>
                   <div>
-                    {content.shortContent ?? getExcerpt(content.content)}
+                    {content.shortContent || getExcerpt(content.content)}
                   </div>
                 </Link>
               </div>

--- a/src/components/utils/styles.ts
+++ b/src/components/utils/styles.ts
@@ -10,16 +10,49 @@ export const renderedStyles = {
   a: "underline text-primary text-sm font-medium",
 };
 
-export const getExcerpt = (content?: string | null) => {
+const htmlEntities: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&apos;": "'",
+  "&nbsp;": " ",
+  "&mdash;": "—",
+  "&ndash;": "–",
+  "&hellip;": "…",
+  "&lsquo;": "‘",
+  "&rsquo;": "’",
+  "&ldquo;": "“",
+  "&rdquo;": "”",
+  "&copy;": "©",
+  "&trade;": "™",
+};
+
+const decodeHtmlEntities = (text: string) =>
+  text
+    .replace(/&#(x?)([0-9a-f]+);/gi, (_, hex, code) =>
+      String.fromCodePoint(parseInt(code, hex ? 16 : 10)),
+    )
+    .replace(/&\w+;/g, (entity) => htmlEntities[entity] || entity);
+
+export const getExcerpt = (content?: string | null, maxLength = 300) => {
   if (!content) {
     return "";
   }
 
-  const text = removeMarkdown(content);
+  const text = decodeHtmlEntities(
+    removeMarkdown(content)
+      .replace(/<[^>]*>/g, "")
+      .replace(/\\/g, ""),
+  )
+    .replace(/\s+/g, " ")
+    .trim();
 
-  if (text.length > 300) {
-    return `${text.slice(0, 300)}...`;
+  if (text.length <= maxLength) {
+    return text;
   }
 
-  return text;
+  const truncated = text.lastIndexOf(" ", maxLength);
+  return `${text.slice(0, truncated > 0 ? truncated : maxLength)}...`;
 };


### PR DESCRIPTION
Hello!

This PR proposes a slightly more advanced version of the `getExcerpt` function. It does 3 things:

1. Instead of capping it at an exact letter count, it uses the cap as a suggestion, and rounds it to the nearest word. Excerpts look more intentional when we're not cutting off any wor... (Read more ->)
2. This function also handles any artifacts from html and markdown, producing a clean output text.
3. The excerpt length defaults to 300 characters, but a custom length can be passed as a second argument. This makes the helper more reusable for different excerpts across a project.

A thing to note is that the artifact handling uses a hard coded list, with (what I think) is the most common characters I've seen in excerpts. There might be reason to pull in a lib for this instead, but I didn't want to add unnecessary dependencies.