### PR TITLE
feat(VenueImage): migrate to sdk-next image, keep local credit wrapper (VEN-329)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@date-fns/tz": "^1.4.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@tanstack/react-query": "^5.90.21",
-    "@venuecms/sdk-next": "^1.9.0",
+    "@venuecms/sdk-next": "^1.10.0",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.460.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.4)
       '@venuecms/sdk-next':
-        specifier: ^1.9.0
-        version: 1.9.0(@swc/core@1.15.18)(jiti@1.21.7)(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postcss@8.5.8)(react@19.2.4)(yaml@2.6.1)
+        specifier: ^1.10.0
+        version: 1.10.0(@swc/core@1.15.18)(jiti@1.21.7)(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postcss@8.5.8)(react@19.2.4)(yaml@2.6.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1078,8 +1078,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@venuecms/sdk-next@1.9.0':
-    resolution: {integrity: sha512-w2iyY6ONOsqprAQXgfdZjaw9va19ETc9TlYnrgtRGx/Fs2hBGV/dF8Jsg8YbIvc2zods9jDfo37J967O14FIRw==}
+  '@venuecms/sdk-next@1.10.0':
+    resolution: {integrity: sha512-3fQG7vsRSx5NNOg28A4d2hgI7zsZeUAmgqx8Twcl8n8JLgTKVrDg5Gca6uzuPpIKrUfhwf6SxVbuhuTxP4+pIg==}
     peerDependencies:
       next: '>=14'
       react: '>=19'
@@ -2636,7 +2636,7 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@venuecms/sdk-next@1.9.0(@swc/core@1.15.18)(jiti@1.21.7)(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postcss@8.5.8)(react@19.2.4)(yaml@2.6.1)':
+  '@venuecms/sdk-next@1.10.0(@swc/core@1.15.18)(jiti@1.21.7)(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postcss@8.5.8)(react@19.2.4)(yaml@2.6.1)':
     dependencies:
       '@types/react': 19.2.14
       '@venuecms/sdk': 1.8.1

--- a/src/components/Event/index.tsx
+++ b/src/components/Event/index.tsx
@@ -3,7 +3,9 @@ import {
   type Event as VenueEvent,
   getLocalizedContent,
 } from "@venuecms/sdk-next";
-import { VenueContent, VenueImage } from "@venuecms/sdk-next";
+import { VenueContent } from "@venuecms/sdk-next";
+
+import { VenueImage } from "@/components/VenueImage";
 import { useLocale } from "next-intl";
 
 import { cn } from "@/lib/utils";

--- a/src/components/EventFeatured/index.tsx
+++ b/src/components/EventFeatured/index.tsx
@@ -3,7 +3,9 @@ import {
   type Event as VenueEvent,
   getLocalizedContent,
 } from "@venuecms/sdk-next";
-import { VenueContent, VenueImage } from "@venuecms/sdk-next";
+import { VenueContent } from "@venuecms/sdk-next";
+
+import { VenueImage } from "@/components/VenueImage";
 import { useLocale } from "next-intl";
 
 import { Link } from "@/lib/i18n";

--- a/src/components/EventList/index.tsx
+++ b/src/components/EventList/index.tsx
@@ -1,5 +1,5 @@
 import { type Event, type Site, getLocalizedContent } from "@venuecms/sdk-next";
-import { VenueImage } from "@venuecms/sdk-next";
+import { VenueImage } from "@/components/VenueImage";
 import { useLocale } from "next-intl";
 import { ReactNode } from "react";
 

--- a/src/components/HomePage/FeaturedEventsContent.tsx
+++ b/src/components/HomePage/FeaturedEventsContent.tsx
@@ -1,4 +1,4 @@
-import { VenueImage } from "@venuecms/sdk-next";
+import { VenueImage } from "@/components/VenueImage";
 import { getEvents, getSite } from "@venuecms/sdk-next";
 import { connection } from "next/server";
 

--- a/src/components/ListProduct/index.tsx
+++ b/src/components/ListProduct/index.tsx
@@ -1,5 +1,5 @@
 import { Product, Site, getLocalizedContent } from "@venuecms/sdk-next";
-import { VenueImage } from "@venuecms/sdk-next";
+import { VenueImage } from "@/components/VenueImage";
 import { useLocale } from "next-intl";
 
 import { Link } from "@/lib/i18n";

--- a/src/components/News/NewsArticle.tsx
+++ b/src/components/News/NewsArticle.tsx
@@ -2,7 +2,9 @@ import {
   type Page as VenuePage,
   getLocalizedContent,
 } from "@venuecms/sdk-next";
-import { VenueContent, VenueImage } from "@venuecms/sdk-next";
+import { VenueContent } from "@venuecms/sdk-next";
+
+import { VenueImage } from "@/components/VenueImage";
 import { format } from "date-fns";
 import { getLocale } from "next-intl/server";
 

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -2,7 +2,9 @@ import {
   type Page as VenuePage,
   getLocalizedContent,
 } from "@venuecms/sdk-next";
-import { VenueContent, VenueImage } from "@venuecms/sdk-next";
+import { VenueContent } from "@venuecms/sdk-next";
+
+import { VenueImage } from "@/components/VenueImage";
 import { useLocale } from "next-intl";
 
 import { PageWithParent } from "@/lib/utils/tree";

--- a/src/components/Product/index.tsx
+++ b/src/components/Product/index.tsx
@@ -4,7 +4,9 @@ import {
   Product as VenueProduct,
   getLocalizedContent,
 } from "@venuecms/sdk-next";
-import { VenueContent, VenueImage } from "@venuecms/sdk-next";
+import { VenueContent } from "@venuecms/sdk-next";
+
+import { VenueImage } from "@/components/VenueImage";
 import { useLocale } from "next-intl";
 
 import { cn } from "@/lib/utils";

--- a/src/components/Profile/index.tsx
+++ b/src/components/Profile/index.tsx
@@ -2,7 +2,9 @@ import {
   type Profile as VenueProfile,
   getLocalizedContent,
 } from "@venuecms/sdk-next";
-import { VenueContent, VenueImage } from "@venuecms/sdk-next";
+import { VenueContent } from "@venuecms/sdk-next";
+
+import { VenueImage } from "@/components/VenueImage";
 import { useLocale, useTranslations } from "next-intl";
 import { Suspense } from "react";
 

--- a/src/components/ProfileCompact/index.tsx
+++ b/src/components/ProfileCompact/index.tsx
@@ -2,7 +2,9 @@ import {
   type Profile as VenueProfile,
   getLocalizedContent,
 } from "@venuecms/sdk-next";
-import { VenueContent, VenueImage } from "@venuecms/sdk-next";
+import { VenueContent } from "@venuecms/sdk-next";
+
+import { VenueImage } from "@/components/VenueImage";
 import { useLocale } from "next-intl";
 
 import { Link } from "@/lib/i18n";

--- a/src/components/SiteLogo/index.tsx
+++ b/src/components/SiteLogo/index.tsx
@@ -1,5 +1,5 @@
 import { Site } from "@venuecms/sdk-next";
-import { VenueImage } from "@venuecms/sdk-next";
+import { VenueImage } from "@/components/VenueImage";
 
 import { Link } from "@/lib/i18n";
 import { cn } from "@/lib/utils";

--- a/src/components/VenueImage/index.tsx
+++ b/src/components/VenueImage/index.tsx
@@ -1,0 +1,45 @@
+import { MediaItem, VenueImage as SdkVenueImage } from "@venuecms/sdk-next";
+
+const ASPECTS = {
+  square: "aspect-square",
+  video: "aspect-video",
+};
+
+export const VenueImage = ({
+  className,
+  image,
+  aspect,
+  props,
+}: {
+  className?: string;
+  image?: Partial<MediaItem>;
+  aspect?: keyof typeof ASPECTS;
+  props?: object;
+}) => (
+  <CreditWrapper credit={image?.credit}>
+    <SdkVenueImage
+      className={className}
+      image={image}
+      aspect={aspect}
+      props={props}
+    />
+  </CreditWrapper>
+);
+
+const CreditWrapper = ({
+  children,
+  credit,
+}: {
+  children?: React.ReactNode;
+  credit?: string | null;
+}) =>
+  credit ? (
+    <div className="relative">
+      {children}
+      <div className="absolute bottom--1 right-0 text-end text-xs text-muted opacity-60">
+        {credit}
+      </div>
+    </div>
+  ) : (
+    children
+  );


### PR DESCRIPTION
Migrates template-minimal to sdk-next 1.10.0 image-only `VenueImage`. Adds local `VenueImage` wrapper that re-adds the overlay credit matching the prior 1.9.0 built-in style, so credits stay byte-identical. Bumps `@venuecms/sdk-next` to ^1.10.0.