### PR TITLE
feat(pages): render a listing layout for listing page types (VEN-521)

### DIFF
--- a/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
@@ -1,11 +1,3 @@
-/**
- * The one thing only this route can get wrong: choosing a layout.
- *
- * `PageListing` is covered where it lives, and so is the type-to-layout map.
- * What neither sees is whether this segment consults the map at all — a page
- * typed as the site's event listing that quietly renders the page layout is a
- * blank-looking page, not an error.
- */
 import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
@@ -81,17 +73,12 @@ describe("the page route", () => {
   });
 
   it("still renders a listing when the page tree cannot be read", async () => {
-    // A listing draws from its own endpoint. Deciding the layout after the
-    // page-tree guard would 404 it over a read only the page layout needs —
-    // and the pages read is the one this route makes purely for subpages.
     expect(await renderRoute("PRODUCTLIST", true)).toContain(
       'data-testid="page-listing"',
     );
   });
 
   it("keeps a page typed as a listing this template has no index for", async () => {
-    // There is no profiles index here, so PROFILELIST resolves to no layout and
-    // the page renders its own content rather than nothing at all.
     expect(await renderRoute("PROFILELIST")).toContain(
       'data-testid="page-layout"',
     );

--- a/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * The one thing only this route can get wrong: choosing a layout.
+ *
+ * `PageListing` is covered where it lives, and so is the type-to-layout map.
+ * What neither sees is whether this segment consults the map at all — a page
+ * typed as the site's event listing that quietly renders the page layout is a
+ * blank-looking page, not an error.
+ */
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import PagePage from "./page";
+
+vi.mock("@/lib", () => ({ getGenerateMetadata: () => () => ({}) }));
+vi.mock("@/components/utils", () => ({ setupSSR: async () => {} }));
+vi.mock("@/components", () => ({
+  Page: () => <div data-testid="page-layout" />,
+}));
+vi.mock("@/components/PageListing", () => ({
+  PageListing: (props: Record<string, unknown>) => (
+    <div
+      data-testid="page-listing"
+      data-layout={typeof props.layout === "string" ? props.layout : undefined}
+      data-title={typeof props.title === "string" ? props.title : undefined}
+      data-base-path={
+        typeof props.basePath === "string" ? props.basePath : undefined
+      }
+    />
+  ),
+}));
+
+const { reads } = vi.hoisted(() => ({
+  reads: { pageType: "CONTENT", pagesReadFails: false },
+}));
+
+vi.mock("@venuecms/sdk-next", () => ({
+  getPage: async () => ({
+    data: { id: "p1", type: reads.pageType, localizedContent: [] },
+  }),
+  getPages: async () => ({
+    data: reads.pagesReadFails ? null : { records: [] },
+  }),
+  getLocalizedContent: () => ({ content: { title: "What's On" } }),
+}));
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(node);
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+const renderRoute = async (type: string, pagesReadFails = false) => {
+  reads.pageType = type;
+  reads.pagesReadFails = pagesReadFails;
+
+  return render(
+    await PagePage({
+      params: Promise.resolve({
+        siteKey: "a-site",
+        locale: "en",
+        slug: "whats-on",
+      }),
+      searchParams: Promise.resolve({ page: "2" }),
+    }),
+  );
+};
+
+describe("the page route", () => {
+  it("renders an ordinary page with the page layout", async () => {
+    expect(await renderRoute("CONTENT")).toContain('data-testid="page-layout"');
+  });
+
+  it("renders a listing page with its listing, paged against its own path", async () => {
+    const html = await renderRoute("EVENTLIST");
+
+    expect(html).not.toContain('data-testid="page-layout"');
+    expect(html).toContain('data-layout="events"');
+    expect(html).toContain('data-title="What&#x27;s On"');
+    expect(html).toContain('data-base-path="/p/whats-on"');
+  });
+
+  it("still renders a listing when the page tree cannot be read", async () => {
+    // A listing draws from its own endpoint. Deciding the layout after the
+    // page-tree guard would 404 it over a read only the page layout needs —
+    // and the pages read is the one this route makes purely for subpages.
+    expect(await renderRoute("PRODUCTLIST", true)).toContain(
+      'data-testid="page-listing"',
+    );
+  });
+
+  it("keeps a page typed as a listing this template has no index for", async () => {
+    // There is no profiles index here, so PROFILELIST resolves to no layout and
+    // the page renders its own content rather than nothing at all.
+    expect(await renderRoute("PROFILELIST")).toContain(
+      'data-testid="page-layout"',
+    );
+  });
+});

--- a/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
@@ -10,7 +10,10 @@ vi.mock("@/components", () => ({
   Page: () => <div data-testid="page-layout" />,
 }));
 vi.mock("@/components/PageListing", () => ({
-  PageListing: (props: Record<string, unknown>) => (
+  PageListing: ({
+    content,
+    ...props
+  }: Record<string, unknown> & { content?: { content?: string | null } }) => (
     <div
       data-testid="page-listing"
       data-layout={typeof props.layout === "string" ? props.layout : undefined}
@@ -18,6 +21,7 @@ vi.mock("@/components/PageListing", () => ({
       data-base-path={
         typeof props.basePath === "string" ? props.basePath : undefined
       }
+      data-content={content?.content ?? undefined}
     />
   ),
 }));
@@ -33,7 +37,9 @@ vi.mock("@venuecms/sdk-next", () => ({
   getPages: async () => ({
     data: reads.pagesReadFails ? null : { records: [] },
   }),
-  getLocalizedContent: () => ({ content: { title: "What's On" } }),
+  getLocalizedContent: () => ({
+    content: { title: "What's On", content: "Season notes" },
+  }),
 }));
 
 const render = async (node: ReactNode) => {
@@ -70,6 +76,12 @@ describe("the page route", () => {
     expect(html).toContain('data-layout="events"');
     expect(html).toContain('data-title="What&#x27;s On"');
     expect(html).toContain('data-base-path="/p/whats-on"');
+  });
+
+  it("hands the listing the page's own content to render", async () => {
+    expect(await renderRoute("EVENTLIST")).toContain(
+      'data-content="Season notes"',
+    );
   });
 
   it("still renders a listing when the page tree cannot be read", async () => {

--- a/src/app/[siteKey]/[locale]/p/[slug]/page.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.tsx
@@ -38,10 +38,7 @@ const PagePage = async ({
       notFound();
     }
 
-    // A page typed as one of the site's listings renders that listing instead
-    // of its own content, so the index looks the same wherever an author puts
-    // it. Decided before the page tree is read at all: a listing draws from its
-    // own endpoint, and the tree is something only the page layout needs.
+    // Resolved before the page tree is read: only the page layout needs the tree.
     const listingLayout = resolvePageListingLayout(page.type);
 
     if (listingLayout) {
@@ -58,7 +55,6 @@ const PagePage = async ({
       );
     }
 
-    // The page layout draws the subpage tree, so it does need the page list.
     const { data: pages } = await getPages();
 
     if (!pages) {

--- a/src/app/[siteKey]/[locale]/p/[slug]/page.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { NewsView, Page } from "@/components";
+import { Page } from "@/components";
 import { getGenerateMetadata } from "@/lib";
 import { Params } from "@/types";
 import { type SearchParams, getLocalizedContent } from "@venuecms/sdk-next";
@@ -7,7 +7,9 @@ import { notFound } from "next/navigation";
 
 import { PageWithParent } from "@/lib/utils/tree";
 
+import { PageListing } from "@/components/PageListing";
 import { setupSSR } from "@/components/utils";
+import { resolvePageListingLayout } from "@/components/utils/pageLayout";
 
 export const generateMetadata = getGenerateMetadata(getPage);
 
@@ -31,20 +33,36 @@ const PagePage = async ({
 
   try {
     const { data: page } = await getPage({ slug });
-    const { data: pages } = await getPages();
 
-    if (!page || !pages) {
+    if (!page) {
       notFound();
     }
 
-    if (page.type === "NEWS" || page.type === "NEWSLIST") {
+    // A page typed as one of the site's listings renders that listing instead
+    // of its own content, so the index looks the same wherever an author puts
+    // it. Decided before the page tree is read at all: a listing draws from its
+    // own endpoint, and the tree is something only the page layout needs.
+    const listingLayout = resolvePageListingLayout(page.type);
+
+    if (listingLayout) {
       const { content } = getLocalizedContent(page.localizedContent, locale);
+
       return (
-        <NewsView
+        <PageListing
+          layout={listingLayout}
+          locale={locale}
           title={content.title ?? undefined}
+          basePath={`/p/${slug}`}
           searchParams={resolvedSearchParams}
         />
       );
+    }
+
+    // The page layout draws the subpage tree, so it does need the page list.
+    const { data: pages } = await getPages();
+
+    if (!pages) {
+      notFound();
     }
 
     return (

--- a/src/app/[siteKey]/[locale]/p/[slug]/page.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.tsx
@@ -49,6 +49,7 @@ const PagePage = async ({
           layout={listingLayout}
           locale={locale}
           title={content.title ?? undefined}
+          content={content}
           basePath={`/p/${slug}`}
           searchParams={resolvedSearchParams}
         />

--- a/src/app/[siteKey]/[locale]/shop/page.tsx
+++ b/src/app/[siteKey]/[locale]/shop/page.tsx
@@ -21,7 +21,13 @@ const ProductsPage = async ({
 
   const currentPage = parseInt((await searchParams)?.page as string, 10) || 0;
 
-  return <ProductsListSection locale={locale} currentPage={currentPage} />;
+  return (
+    <ProductsListSection
+      locale={locale}
+      currentPage={currentPage}
+      basePath="/shop"
+    />
+  );
 };
 
 export default ProductsPage;

--- a/src/components/EventsPage/EventsListContent.test.tsx
+++ b/src/components/EventsPage/EventsListContent.test.tsx
@@ -5,8 +5,13 @@ import { renderToReadableStream } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { EventsListContent } from "./EventsListContent";
+import { EventsListSection } from "./EventsListSection";
 
 vi.mock("next/server", () => ({ connection: async () => {} }));
+
+// ColumnLeft is emitted first, so a body moved into it still reads as "before
+// the events" unless the assertion names the column that should hold it.
+const columnRight = (html: string) => html.split('class="col-span-2')[1] ?? "";
 
 const render = async (node: ReactNode) => {
   const stream = await renderToReadableStream(
@@ -79,15 +84,31 @@ describe("the events listing heading", () => {
   });
 
   it("renders a body it was handed above the events", async () => {
-    const html = await render(
-      <EventsListContent locale="en" title="What's On">
-        <p>Season notes</p>
-      </EventsListContent>,
+    const column = columnRight(
+      await render(
+        <EventsListContent locale="en" title="What's On">
+          <p>Season notes</p>
+        </EventsListContent>,
+      ),
     );
 
-    expect(html.indexOf("Season notes")).toBeGreaterThan(-1);
-    expect(html.indexOf("Season notes")).toBeLessThan(
-      html.indexOf("No events found"),
+    expect(column.indexOf("Season notes")).toBeGreaterThan(-1);
+    expect(column.indexOf("Season notes")).toBeLessThan(
+      column.indexOf("No events found"),
     );
+  });
+});
+
+describe("the events listing section", () => {
+  it("hands the body it was given to the content it wraps", async () => {
+    const column = columnRight(
+      await render(
+        <EventsListSection locale="en" title="What's On">
+          <p>Season notes</p>
+        </EventsListSection>,
+      ),
+    );
+
+    expect(column).toContain("Season notes");
   });
 });

--- a/src/components/EventsPage/EventsListContent.test.tsx
+++ b/src/components/EventsPage/EventsListContent.test.tsx
@@ -1,17 +1,3 @@
-/**
- * The heading, which is the one thing this listing reads that its caller can
- * now know better than it does.
- *
- * `/events` has no title of its own and looks the /events page record up for
- * one. A page typed as the event listing already holds the title an author
- * wrote, and a heading that ignored it would leave that page announcing itself
- * as whatever the /events record says — a wrong heading, not a missing one, so
- * nothing about it looks broken.
- *
- * `connection()` is stubbed for the same reason as in the shop's test: the
- * component calls it to opt out of the prerender and it throws outside a Next
- * request scope.
- */
 import { setConfig } from "@venuecms/sdk-next";
 import { NextIntlClientProvider } from "next-intl";
 import type { ReactNode } from "react";
@@ -44,8 +30,7 @@ beforeEach(() => {
       settings: {},
     };
 
-    // Pages first: the page record for this listing lives at /pages/events,
-    // which the events branch would otherwise swallow.
+    // Pages first: /pages/events would otherwise match the events branch.
     if (url.includes("/pages")) {
       body = {
         id: "page-id",

--- a/src/components/EventsPage/EventsListContent.test.tsx
+++ b/src/components/EventsPage/EventsListContent.test.tsx
@@ -77,4 +77,17 @@ describe("the events listing heading", () => {
 
     expect(requested.some((url) => url.includes("/pages"))).toBe(false);
   });
+
+  it("renders a body it was handed above the events", async () => {
+    const html = await render(
+      <EventsListContent locale="en" title="What's On">
+        <p>Season notes</p>
+      </EventsListContent>,
+    );
+
+    expect(html.indexOf("Season notes")).toBeGreaterThan(-1);
+    expect(html.indexOf("Season notes")).toBeLessThan(
+      html.indexOf("No events found"),
+    );
+  });
 });

--- a/src/components/EventsPage/EventsListContent.test.tsx
+++ b/src/components/EventsPage/EventsListContent.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * The heading, which is the one thing this listing reads that its caller can
+ * now know better than it does.
+ *
+ * `/events` has no title of its own and looks the /events page record up for
+ * one. A page typed as the event listing already holds the title an author
+ * wrote, and a heading that ignored it would leave that page announcing itself
+ * as whatever the /events record says — a wrong heading, not a missing one, so
+ * nothing about it looks broken.
+ *
+ * `connection()` is stubbed for the same reason as in the shop's test: the
+ * component calls it to opt out of the prerender and it throws outside a Next
+ * request scope.
+ */
+import { setConfig } from "@venuecms/sdk-next";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EventsListContent } from "./EventsListContent";
+
+vi.mock("next/server", () => ({ connection: async () => {} }));
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(
+    <NextIntlClientProvider locale="en" messages={{}}>
+      {node}
+    </NextIntlClientProvider>,
+  );
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+beforeEach(() => {
+  setConfig({ siteKey: "test-site" });
+
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = input instanceof Request ? input.url : String(input);
+
+    let body: unknown = {
+      id: "site-id",
+      timeZone: "Europe/Berlin",
+      settings: {},
+    };
+
+    // Pages first: the page record for this listing lives at /pages/events,
+    // which the events branch would otherwise swallow.
+    if (url.includes("/pages")) {
+      body = {
+        id: "page-id",
+        slug: "events",
+        localizedContent: [
+          { siteId: "site-id", locale: "en", title: "Upcoming Events" },
+        ],
+      };
+    } else if (url.includes("/events")) {
+      body = { records: [], count: 0 };
+    }
+
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("the events listing heading", () => {
+  it("reads the /events page record when no title was handed to it", async () => {
+    const html = await render(<EventsListContent locale="en" />);
+
+    expect(html).toContain("Upcoming Events");
+  });
+
+  it("prefers the title it was given, and does not read the page record", async () => {
+    const html = await render(
+      <EventsListContent locale="en" title="What's On" />,
+    );
+
+    expect(html).toContain("What&#x27;s On");
+    expect(html).not.toContain("Upcoming Events");
+
+    const requested = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.map(([input]) =>
+        input instanceof Request ? input.url : String(input),
+      );
+
+    expect(requested.some((url) => url.includes("/pages"))).toBe(false);
+  });
+});

--- a/src/components/EventsPage/EventsListContent.tsx
+++ b/src/components/EventsPage/EventsListContent.tsx
@@ -11,22 +11,14 @@ export async function EventsListContent({
   title,
 }: {
   locale: string;
-  /**
-   * The heading, when the caller already knows it.
-   *
-   * `/events` passes none and looks up the page record slugged "events" for
-   * one. A page typed as the event listing stands in for that route and holds
-   * the title an author actually wrote, so it passes its own — otherwise such
-   * a page would head itself with a title from a different record entirely.
-   */
+  /** Heading; a listing page passes its own, else the "events" record is read for one. */
   title?: string;
 }) {
   await connection();
 
   const [{ data: events }, { data: page }, { data: site }] = await Promise.all([
     getEvents({ limit: 60, upcoming: true }),
-    // Skipped when the caller brought a title: the page record is read for
-    // nothing else here.
+    // Read for the title only, so skipped when the caller brought one.
     title ? { data: null } : getPage({ slug: "events" }),
     getSite(),
   ]);

--- a/src/components/EventsPage/EventsListContent.tsx
+++ b/src/components/EventsPage/EventsListContent.tsx
@@ -9,10 +9,13 @@ import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
 export async function EventsListContent({
   locale,
   title,
+  children,
 }: {
   locale: string;
   /** Heading; a listing page passes its own, else the "events" record is read for one. */
   title?: string;
+  /** The page's body, above the events; absent on the `/events` route. */
+  children?: React.ReactNode;
 }) {
   await connection();
 
@@ -39,6 +42,7 @@ export async function EventsListContent({
         <p className="pb-8 text-primary">{pageTitle}</p>
       </ColumnLeft>
       <ColumnRight>
+        {children}
         {events?.records.length ? (
           <EventsList className="gap-y-12">
             {events.records.map((event) => (

--- a/src/components/EventsPage/EventsListContent.tsx
+++ b/src/components/EventsPage/EventsListContent.tsx
@@ -6,12 +6,28 @@ import { connection } from "next/server";
 import { EventsList, ListEvent } from "@/components/EventList";
 import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
 
-export async function EventsListContent({ locale }: { locale: string }) {
+export async function EventsListContent({
+  locale,
+  title,
+}: {
+  locale: string;
+  /**
+   * The heading, when the caller already knows it.
+   *
+   * `/events` passes none and looks up the page record slugged "events" for
+   * one. A page typed as the event listing stands in for that route and holds
+   * the title an author actually wrote, so it passes its own — otherwise such
+   * a page would head itself with a title from a different record entirely.
+   */
+  title?: string;
+}) {
   await connection();
 
   const [{ data: events }, { data: page }, { data: site }] = await Promise.all([
     getEvents({ limit: 60, upcoming: true }),
-    getPage({ slug: "events" }),
+    // Skipped when the caller brought a title: the page record is read for
+    // nothing else here.
+    title ? { data: null } : getPage({ slug: "events" }),
     getSite(),
   ]);
 
@@ -19,9 +35,11 @@ export async function EventsListContent({ locale }: { locale: string }) {
     notFound();
   }
 
-  const pageTitle = page
-    ? getLocalizedContent(page.localizedContent, locale).content.title
-    : "upcoming events";
+  const pageTitle =
+    title ??
+    (page
+      ? getLocalizedContent(page.localizedContent, locale).content.title
+      : "upcoming events");
 
   return (
     <TwoColumnLayout>

--- a/src/components/EventsPage/EventsListContent.tsx
+++ b/src/components/EventsPage/EventsListContent.tsx
@@ -14,7 +14,6 @@ export async function EventsListContent({
   locale: string;
   /** Heading; a listing page passes its own, else the "events" record is read for one. */
   title?: string;
-  /** The page's body, above the events; absent on the `/events` route. */
   children?: React.ReactNode;
 }) {
   await connection();

--- a/src/components/EventsPage/EventsListSection.tsx
+++ b/src/components/EventsPage/EventsListSection.tsx
@@ -51,7 +51,6 @@ export function EventsListSection({
   title,
 }: {
   locale: string;
-  /** The heading, when the caller knows it. See {@link EventsListContent}. */
   title?: string;
 }) {
   return (

--- a/src/components/EventsPage/EventsListSection.tsx
+++ b/src/components/EventsPage/EventsListSection.tsx
@@ -53,7 +53,6 @@ export function EventsListSection({
 }: {
   locale: string;
   title?: string;
-  /** The page's body, above the events; absent on the `/events` route. */
   children?: React.ReactNode;
 }) {
   return (

--- a/src/components/EventsPage/EventsListSection.tsx
+++ b/src/components/EventsPage/EventsListSection.tsx
@@ -49,14 +49,19 @@ function EventsListSkeleton() {
 export function EventsListSection({
   locale,
   title,
+  children,
 }: {
   locale: string;
   title?: string;
+  /** The page's body, above the events; absent on the `/events` route. */
+  children?: React.ReactNode;
 }) {
   return (
     <ErrorBoundary fallback={<EventsListError />}>
       <Suspense fallback={<EventsListSkeleton />}>
-        <EventsListContent locale={locale} title={title} />
+        <EventsListContent locale={locale} title={title}>
+          {children}
+        </EventsListContent>
       </Suspense>
     </ErrorBoundary>
   );

--- a/src/components/EventsPage/EventsListSection.tsx
+++ b/src/components/EventsPage/EventsListSection.tsx
@@ -46,11 +46,18 @@ function EventsListSkeleton() {
   );
 }
 
-export function EventsListSection({ locale }: { locale: string }) {
+export function EventsListSection({
+  locale,
+  title,
+}: {
+  locale: string;
+  /** The heading, when the caller knows it. See {@link EventsListContent}. */
+  title?: string;
+}) {
   return (
     <ErrorBoundary fallback={<EventsListError />}>
       <Suspense fallback={<EventsListSkeleton />}>
-        <EventsListContent locale={locale} />
+        <EventsListContent locale={locale} title={title} />
       </Suspense>
     </ErrorBoundary>
   );

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * The dispatch itself, with the three listings stubbed.
+ *
+ * How a listing looks is covered where it lives — these are the same sections
+ * `/news`, `/events` and `/shop` render. What only this component can get wrong
+ * is which one a layout reaches, and the two things only `/p/<slug>` knows that
+ * have to survive the trip: the page's own title, and the path a pager builds
+ * hrefs against. The second fails quietly, paging a reader off to `/shop`.
+ */
+import { MAX_PAGE } from "@venuecms/sdk-next";
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { PageListing } from "./index";
+
+// A function declaration, not a const: the mock factories below run while the
+// hoisted `./index` import is resolved, before any top-level `const` on this
+// module has initialised.
+function stub(testId: string) {
+  return (props: Record<string, unknown>) => (
+    <div
+      data-testid={testId}
+      data-title={typeof props.title === "string" ? props.title : undefined}
+      data-base-path={
+        typeof props.basePath === "string" ? props.basePath : undefined
+      }
+      data-current-page={
+        typeof props.currentPage === "number"
+          ? String(props.currentPage)
+          : undefined
+      }
+    />
+  );
+}
+
+vi.mock("@/components/News", () => ({ NewsView: stub("news-view") }));
+vi.mock("@/components/EventsPage", () => ({
+  EventsListSection: stub("events-view"),
+}));
+vi.mock("@/components/ShopPage", () => ({
+  ProductsListSection: stub("products-view"),
+}));
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(node);
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+const renderListing = (props: Partial<Parameters<typeof PageListing>[0]>) =>
+  render(
+    <PageListing
+      layout="events"
+      locale="en"
+      basePath="/p/whats-on"
+      searchParams={{}}
+      {...props}
+    />,
+  );
+
+describe("PageListing", () => {
+  it.each([
+    ["news", "news-view"],
+    ["events", "events-view"],
+    ["products", "products-view"],
+  ] as const)("renders the %s listing", async (layout, testId) => {
+    expect(await renderListing({ layout })).toContain(
+      `data-testid="${testId}"`,
+    );
+  });
+
+  it.each([
+    ["news", "news-view"],
+    ["events", "events-view"],
+  ] as const)(
+    "gives the %s listing the page's own title",
+    async (layout, testId) => {
+      // Events as well as news: a title that reaches the dispatcher and is then
+      // dropped leaves an author's page announcing itself with whatever heading
+      // the static route reads for itself — a wrong title rather than a missing
+      // one, and nothing about that failure is visible at the call site.
+      const html = await renderListing({ layout, title: "Dispatches" });
+
+      expect(html).toContain(`data-testid="${testId}"`);
+      expect(html).toContain('data-title="Dispatches"');
+    },
+  );
+
+  it("gives the products listing no title, having nowhere to draw one", async () => {
+    // This template's shop is a bare grid on /shop too. Showing what an author
+    // wrote above the products is #66's job, not this dispatcher's.
+    const html = await renderListing({ layout: "products", title: "Merch" });
+
+    expect(html).toContain('data-testid="products-view"');
+    expect(html).not.toContain("data-title");
+  });
+
+  it("pages the products listing against the page it is rendered on", async () => {
+    const html = await renderListing({
+      layout: "products",
+      basePath: "/p/merch",
+      searchParams: { page: "2" },
+    });
+
+    expect(html).toContain('data-base-path="/p/merch"');
+    expect(html).toContain('data-current-page="2"');
+  });
+
+  it("takes the first of a repeated page param, as a route would", async () => {
+    // `parseInt` on the array reads "1,2" as 1 by accident. Reading the first
+    // value on purpose is the same rule the SDK's own pagers follow.
+    const html = await renderListing({
+      layout: "products",
+      searchParams: { page: ["1", "2"] },
+    });
+
+    expect(html).toContain('data-current-page="1"');
+  });
+
+  it("starts at the first page rather than fetching a nonsense one", async () => {
+    for (const page of ["not-a-page", "-2", "3abc", "2.5", "1e3", ""]) {
+      expect(
+        await renderListing({ layout: "products", searchParams: { page } }),
+      ).toContain('data-current-page="0"');
+    }
+
+    expect(
+      await renderListing({ layout: "products", searchParams: {} }),
+    ).toContain('data-current-page="0"');
+  });
+
+  it("clamps a hand-edited page rather than handing it to the endpoint", async () => {
+    // The endpoints page by offset, so an arbitrary number off the query string
+    // is an arbitrary offset for the database to walk. Clamping rather than
+    // resetting leaves the deepest reachable page a link back.
+    const html = await renderListing({
+      layout: "products",
+      searchParams: { page: String(MAX_PAGE + 5000) },
+    });
+
+    expect(html).toContain(`data-current-page="${MAX_PAGE}"`);
+  });
+});

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -1,12 +1,3 @@
-/**
- * The dispatch itself, with the three listings stubbed.
- *
- * How a listing looks is covered where it lives — these are the same sections
- * `/news`, `/events` and `/shop` render. What only this component can get wrong
- * is which one a layout reaches, and the two things only `/p/<slug>` knows that
- * have to survive the trip: the page's own title, and the path a pager builds
- * hrefs against. The second fails quietly, paging a reader off to `/shop`.
- */
 import { MAX_PAGE } from "@venuecms/sdk-next";
 import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
@@ -14,9 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { PageListing } from "./index";
 
-// A function declaration, not a const: the mock factories below run while the
-// hoisted `./index` import is resolved, before any top-level `const` on this
-// module has initialised.
+// Declaration, not const: mock factories run before this module's consts init.
 function stub(testId: string) {
   return (props: Record<string, unknown>) => (
     <div
@@ -76,10 +65,6 @@ describe("PageListing", () => {
   ] as const)(
     "gives the %s listing the page's own title",
     async (layout, testId) => {
-      // Events as well as news: a title that reaches the dispatcher and is then
-      // dropped leaves an author's page announcing itself with whatever heading
-      // the static route reads for itself — a wrong title rather than a missing
-      // one, and nothing about that failure is visible at the call site.
       const html = await renderListing({ layout, title: "Dispatches" });
 
       expect(html).toContain(`data-testid="${testId}"`);
@@ -88,8 +73,6 @@ describe("PageListing", () => {
   );
 
   it("gives the products listing no title, having nowhere to draw one", async () => {
-    // This template's shop is a bare grid on /shop too. Showing what an author
-    // wrote above the products is #66's job, not this dispatcher's.
     const html = await renderListing({ layout: "products", title: "Merch" });
 
     expect(html).toContain('data-testid="products-view"');
@@ -108,8 +91,6 @@ describe("PageListing", () => {
   });
 
   it("takes the first of a repeated page param, as a route would", async () => {
-    // `parseInt` on the array reads "1,2" as 1 by accident. Reading the first
-    // value on purpose is the same rule the SDK's own pagers follow.
     const html = await renderListing({
       layout: "products",
       searchParams: { page: ["1", "2"] },
@@ -131,9 +112,6 @@ describe("PageListing", () => {
   });
 
   it("clamps a hand-edited page rather than handing it to the endpoint", async () => {
-    // The endpoints page by offset, so an arbitrary number off the query string
-    // is an arbitrary offset for the database to walk. Clamping rather than
-    // resetting leaves the deepest reachable page a link back.
     const html = await renderListing({
       layout: "products",
       searchParams: { page: String(MAX_PAGE + 5000) },

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -14,22 +14,32 @@ function stub(testId: string) {
   return ({
     children,
     ...props
-  }: Record<string, unknown> & { children?: ReactNode }) => (
-    <div
-      data-testid={testId}
-      data-title={typeof props.title === "string" ? props.title : undefined}
-      data-base-path={
-        typeof props.basePath === "string" ? props.basePath : undefined
-      }
-      data-current-page={
-        typeof props.currentPage === "number"
-          ? String(props.currentPage)
-          : undefined
-      }
-    >
-      {children}
-    </div>
-  );
+  }: Record<string, unknown> & {
+    children?: ReactNode;
+    searchParams?: SearchParams;
+  }) => {
+    const blockParam = props.searchParams?.evt_9k3z1;
+
+    return (
+      <div
+        data-testid={testId}
+        data-title={typeof props.title === "string" ? props.title : undefined}
+        data-base-path={
+          typeof props.basePath === "string" ? props.basePath : undefined
+        }
+        data-current-page={
+          typeof props.currentPage === "number"
+            ? String(props.currentPage)
+            : undefined
+        }
+        data-block-param={
+          typeof blockParam === "string" ? blockParam : undefined
+        }
+      >
+        {children}
+      </div>
+    );
+  };
 }
 
 function contentStub({
@@ -67,11 +77,10 @@ vi.mock("@venuecms/sdk-next", async (importOriginal) => ({
   VenueContent: contentStub,
 }));
 
-const localizedContent = (content: string | null) => ({
-  siteId: "s1",
-  locale: "en",
-  content,
-});
+const localizedContent = (fields: {
+  content?: string | null;
+  contentJSON?: { [key: string]: unknown } | null;
+}) => ({ siteId: "s1", locale: "en", ...fields });
 
 // The stub views hold nothing but their children, so the markup up to the first
 // close tag is what a view was handed.
@@ -176,7 +185,7 @@ describe("PageListing", () => {
       const html = await renderListing({
         layout,
         searchParams: { page: "2" },
-        content: localizedContent("<p>Season notes</p>"),
+        content: localizedContent({ content: "<p>Season notes</p>" }),
       });
 
       const view = withinView(html, testId);
@@ -191,10 +200,28 @@ describe("PageListing", () => {
   // An empty block would leave the views spacing around nothing.
   it.each([
     ["no localized content", undefined],
-    ["an empty body", localizedContent(null)],
+    ["an empty body", localizedContent({ content: null })],
+    ["a whitespace-only body", localizedContent({ content: "   " })],
+    // What the editor saves for a body its author typed in and then cleared.
+    [
+      "an emptied editor doc",
+      localizedContent({
+        contentJSON: { type: "doc", content: [{ type: "paragraph" }] },
+      }),
+    ],
   ])("renders no content block for %s", async (_label, content) => {
     expect(await renderListing({ layout: "events", content })).not.toContain(
       'data-testid="page-content"',
     );
+  });
+
+  // The body's own listing block pages by a param of its own.
+  it("hands the products listing every param, not just the page", async () => {
+    const html = await renderListing({
+      layout: "products",
+      searchParams: { page: "1", evt_9k3z1: "3" },
+    });
+
+    expect(html).toContain('data-block-param="3"');
   });
 });

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -1,4 +1,8 @@
-import { MAX_PAGE } from "@venuecms/sdk-next";
+import {
+  type ContentEntries,
+  MAX_PAGE,
+  type SearchParams,
+} from "@venuecms/sdk-next";
 import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
@@ -7,7 +11,10 @@ import { PageListing } from "./index";
 
 // Declaration, not const: mock factories run before this module's consts init.
 function stub(testId: string) {
-  return (props: Record<string, unknown>) => (
+  return ({
+    children,
+    ...props
+  }: Record<string, unknown> & { children?: ReactNode }) => (
     <div
       data-testid={testId}
       data-title={typeof props.title === "string" ? props.title : undefined}
@@ -18,6 +25,28 @@ function stub(testId: string) {
         typeof props.currentPage === "number"
           ? String(props.currentPage)
           : undefined
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+function contentStub({
+  contentStyles,
+  searchParams,
+}: {
+  contentStyles?: ContentEntries;
+  searchParams?: SearchParams;
+}) {
+  return (
+    <div
+      data-testid="page-content"
+      data-content-styles={
+        typeof contentStyles?.p === "string" ? contentStyles.p : undefined
+      }
+      data-search-page={
+        typeof searchParams?.page === "string" ? searchParams.page : undefined
       }
     />
   );
@@ -30,6 +59,24 @@ vi.mock("@/components/EventsPage", () => ({
 vi.mock("@/components/ShopPage", () => ({
   ProductsListSection: stub("products-view"),
 }));
+vi.mock("@/components/ListingBlock", () => ({
+  contentComponents: { p: "prose" },
+}));
+vi.mock("@venuecms/sdk-next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@venuecms/sdk-next")>()),
+  VenueContent: contentStub,
+}));
+
+const localizedContent = (content: string | null) => ({
+  siteId: "s1",
+  locale: "en",
+  content,
+});
+
+// The stub views hold nothing but their children, so the markup up to the first
+// close tag is what a view was handed.
+const withinView = (html: string, testId: string) =>
+  html.split(`data-testid="${testId}"`)[1]?.split("</div>")[0] ?? "";
 
 const render = async (node: ReactNode) => {
   const stream = await renderToReadableStream(node);
@@ -118,5 +165,36 @@ describe("PageListing", () => {
     });
 
     expect(html).toContain(`data-current-page="${MAX_PAGE}"`);
+  });
+
+  it.each([
+    ["events", "events-view"],
+    ["products", "products-view"],
+  ] as const)(
+    "renders the page's own content inside the %s listing",
+    async (layout, testId) => {
+      const html = await renderListing({
+        layout,
+        searchParams: { page: "2" },
+        content: localizedContent("<p>Season notes</p>"),
+      });
+
+      const view = withinView(html, testId);
+
+      expect(view).toContain('data-testid="page-content"');
+      // The content's own listing blocks need the styles and the page's params.
+      expect(view).toContain('data-content-styles="prose"');
+      expect(view).toContain('data-search-page="2"');
+    },
+  );
+
+  // An empty block would leave the views spacing around nothing.
+  it.each([
+    ["no localized content", undefined],
+    ["an empty body", localizedContent(null)],
+  ])("renders no content block for %s", async (_label, content) => {
+    expect(await renderListing({ layout: "events", content })).not.toContain(
+      'data-testid="page-content"',
+    );
   });
 });

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -1,19 +1,4 @@
-/**
- * The listing a page renders in place of its own content.
- *
- * A page marked in the CMS as the site's news / events / products index shows
- * that index, not the page layout — which is what lets an author put the index
- * anywhere in the tree and still have it look like `/events`. The dispatch
- * lives here, in one place, so `/p/<slug>` does not grow a chain of page-type
- * branches and so every listing keeps exactly one implementation: these are the
- * same sections the static routes render.
- *
- * Which type maps to which listing is {@link resolvePageListingLayout}'s job;
- * this only renders what that returned.
- *
- * Not to be confused with `PageListingBlock`, which is a listing *of pages*
- * placed inside rich-text content. This is the listing a page *is*.
- */
+/** The listing a page *is*, not `PageListingBlock`, which is a listing of pages. */
 import { MAX_PAGE, type SearchParams } from "@venuecms/sdk-next";
 
 import { EventsListSection } from "@/components/EventsPage";
@@ -21,24 +6,12 @@ import { NewsView } from "@/components/News";
 import { ProductsListSection } from "@/components/ShopPage";
 import type { PageListingLayout } from "@/components/utils/pageLayout";
 
-/**
- * The page a URL is asking the products listing for, or 0.
- *
- * Read inline rather than through a shared helper on purpose. VEN-514 (#69)
- * lands `readPage` with exactly these rules in `components/Pagination`, and two
- * exported readers of one param is how a route's pager and a listing block's
- * pager start answering the same URL differently. This goes when that lands.
- *
- * Digits rather than `Number()`, which reads "0x10" as 16 and "1e3" as 1000 —
- * query strings no link produces, the second quietly asking the endpoint for
- * the deepest offset scan it permits. A repeated param takes its first value,
- * as a route would read `?page=1&page=2`. Past MAX_PAGE clamps rather than
- * resetting, so the deepest reachable page still renders a link back.
- */
+// Duplicates VEN-514's readPage (#69) on purpose; drop when that lands.
 const readPage = (searchParams: SearchParams): number => {
   const raw = searchParams.page;
   const value = Array.isArray(raw) ? raw[0] : raw;
 
+  // Digits only: Number() reads "1e3" as the deepest offset scan the endpoint allows.
   if (typeof value !== "string" || !/^\d+$/.test(value)) {
     return 0;
   }
@@ -55,23 +28,9 @@ export const PageListing = ({
 }: {
   layout: PageListingLayout;
   locale: string;
-  /**
-   * The page's own title, for the listings that draw one.
-   *
-   * News and events both head their layout with a title, and a page an author
-   * titled and then typed as one of those would otherwise announce itself with
-   * whatever heading the static route reads for itself — a wrong title rather
-   * than a missing one. The shop draws no heading at all, on `/shop` or
-   * anywhere else, so there is nothing to hand it; see the products branch.
-   */
   title?: string;
-  /**
-   * The path this page lives at, for any pager the listing draws. Only the
-   * route knows it, and a listing that guessed `/shop` would page a reader
-   * clean off the page they are on.
-   */
+  /** Path any pager builds hrefs against; only the route knows it. */
   basePath: string;
-  /** The route's search params, which carry the page being read. */
   searchParams: SearchParams;
 }) => {
   switch (layout) {
@@ -79,10 +38,7 @@ export const PageListing = ({
       return <NewsView title={title} searchParams={searchParams} />;
     case "events":
       return <EventsListSection locale={locale} title={title} />;
-    // No title: this template's shop is a bare grid with no heading slot to
-    // put one in, and inventing one here would be a layout decision rather
-    // than a port. Showing what an author wrote above the products is what
-    // #66 ("'Shop' page content shows above products") is for.
+    // No title: the shop grid has no heading slot; page content above it is #66.
     case "products":
       return (
         <ProductsListSection

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -1,0 +1,95 @@
+/**
+ * The listing a page renders in place of its own content.
+ *
+ * A page marked in the CMS as the site's news / events / products index shows
+ * that index, not the page layout — which is what lets an author put the index
+ * anywhere in the tree and still have it look like `/events`. The dispatch
+ * lives here, in one place, so `/p/<slug>` does not grow a chain of page-type
+ * branches and so every listing keeps exactly one implementation: these are the
+ * same sections the static routes render.
+ *
+ * Which type maps to which listing is {@link resolvePageListingLayout}'s job;
+ * this only renders what that returned.
+ *
+ * Not to be confused with `PageListingBlock`, which is a listing *of pages*
+ * placed inside rich-text content. This is the listing a page *is*.
+ */
+import { MAX_PAGE, type SearchParams } from "@venuecms/sdk-next";
+
+import { EventsListSection } from "@/components/EventsPage";
+import { NewsView } from "@/components/News";
+import { ProductsListSection } from "@/components/ShopPage";
+import type { PageListingLayout } from "@/components/utils/pageLayout";
+
+/**
+ * The page a URL is asking the products listing for, or 0.
+ *
+ * Read inline rather than through a shared helper on purpose. VEN-514 (#69)
+ * lands `readPage` with exactly these rules in `components/Pagination`, and two
+ * exported readers of one param is how a route's pager and a listing block's
+ * pager start answering the same URL differently. This goes when that lands.
+ *
+ * Digits rather than `Number()`, which reads "0x10" as 16 and "1e3" as 1000 —
+ * query strings no link produces, the second quietly asking the endpoint for
+ * the deepest offset scan it permits. A repeated param takes its first value,
+ * as a route would read `?page=1&page=2`. Past MAX_PAGE clamps rather than
+ * resetting, so the deepest reachable page still renders a link back.
+ */
+const readPage = (searchParams: SearchParams): number => {
+  const raw = searchParams.page;
+  const value = Array.isArray(raw) ? raw[0] : raw;
+
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    return 0;
+  }
+
+  return Math.min(Number(value), MAX_PAGE);
+};
+
+export const PageListing = ({
+  layout,
+  locale,
+  title,
+  basePath,
+  searchParams,
+}: {
+  layout: PageListingLayout;
+  locale: string;
+  /**
+   * The page's own title, for the listings that draw one.
+   *
+   * News and events both head their layout with a title, and a page an author
+   * titled and then typed as one of those would otherwise announce itself with
+   * whatever heading the static route reads for itself — a wrong title rather
+   * than a missing one. The shop draws no heading at all, on `/shop` or
+   * anywhere else, so there is nothing to hand it; see the products branch.
+   */
+  title?: string;
+  /**
+   * The path this page lives at, for any pager the listing draws. Only the
+   * route knows it, and a listing that guessed `/shop` would page a reader
+   * clean off the page they are on.
+   */
+  basePath: string;
+  /** The route's search params, which carry the page being read. */
+  searchParams: SearchParams;
+}) => {
+  switch (layout) {
+    case "news":
+      return <NewsView title={title} searchParams={searchParams} />;
+    case "events":
+      return <EventsListSection locale={locale} title={title} />;
+    // No title: this template's shop is a bare grid with no heading slot to
+    // put one in, and inventing one here would be a layout decision rather
+    // than a port. Showing what an author wrote above the products is what
+    // #66 ("'Shop' page content shows above products") is for.
+    case "products":
+      return (
+        <ProductsListSection
+          locale={locale}
+          basePath={basePath}
+          currentPage={readPage(searchParams)}
+        />
+      );
+  }
+};

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -10,6 +10,7 @@ import { EventsListSection } from "@/components/EventsPage";
 import { contentComponents } from "@/components/ListingBlock";
 import { NewsView } from "@/components/News";
 import { ProductsListSection } from "@/components/ShopPage";
+import { hasRenderableContent } from "@/components/utils/pageContent";
 import type { PageListingLayout } from "@/components/utils/pageLayout";
 
 // Duplicates VEN-514's readPage (#69) on purpose; drop when that lands.
@@ -36,16 +37,16 @@ export const PageListing = ({
   layout: PageListingLayout;
   locale: string;
   title?: string;
-  /** The page's own body, which is a listing's content as much as the records are. */
+  /** The page's own body, rendered above the records. */
   content?: LocalizedContent;
   /** Path any pager builds hrefs against; only the route knows it. */
   basePath: string;
   searchParams: SearchParams;
 }) => {
-  // Emptiness decided here, not in the views: a VenueContent that renders null
-  // still leaves them holding a spacer around nothing.
+  // Emptiness decided here, not in the views, which would otherwise space
+  // around a VenueContent that renders nothing.
   const body =
-    content?.content || content?.contentJSON ? (
+    content && hasRenderableContent(content) ? (
       <VenueContent
         className="flex max-w-[42rem] flex-col gap-6 text-sm"
         content={content}
@@ -55,7 +56,7 @@ export const PageListing = ({
     ) : null;
 
   switch (layout) {
-    // No body: the news layout already renders an article's content in full.
+    // No body: this layout renders the latest article's, and two would compete.
     case "news":
       return <NewsView title={title} searchParams={searchParams} />;
     case "events":
@@ -71,6 +72,7 @@ export const PageListing = ({
           locale={locale}
           basePath={basePath}
           currentPage={readPage(searchParams)}
+          searchParams={searchParams}
         >
           {body}
         </ProductsListSection>

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -1,7 +1,13 @@
 /** The listing a page *is*, not `PageListingBlock`, which is a listing of pages. */
-import { MAX_PAGE, type SearchParams } from "@venuecms/sdk-next";
+import {
+  type LocalizedContent,
+  MAX_PAGE,
+  type SearchParams,
+  VenueContent,
+} from "@venuecms/sdk-next";
 
 import { EventsListSection } from "@/components/EventsPage";
+import { contentComponents } from "@/components/ListingBlock";
 import { NewsView } from "@/components/News";
 import { ProductsListSection } from "@/components/ShopPage";
 import type { PageListingLayout } from "@/components/utils/pageLayout";
@@ -23,29 +29,51 @@ export const PageListing = ({
   layout,
   locale,
   title,
+  content,
   basePath,
   searchParams,
 }: {
   layout: PageListingLayout;
   locale: string;
   title?: string;
+  /** The page's own body, which is a listing's content as much as the records are. */
+  content?: LocalizedContent;
   /** Path any pager builds hrefs against; only the route knows it. */
   basePath: string;
   searchParams: SearchParams;
 }) => {
+  // Emptiness decided here, not in the views: a VenueContent that renders null
+  // still leaves them holding a spacer around nothing.
+  const body =
+    content?.content || content?.contentJSON ? (
+      <VenueContent
+        className="flex max-w-[42rem] flex-col gap-6 text-sm"
+        content={content}
+        contentStyles={contentComponents}
+        searchParams={searchParams}
+      />
+    ) : null;
+
   switch (layout) {
+    // No body: the news layout already renders an article's content in full.
     case "news":
       return <NewsView title={title} searchParams={searchParams} />;
     case "events":
-      return <EventsListSection locale={locale} title={title} />;
-    // No title: the shop grid has no heading slot; page content above it is #66.
+      return (
+        <EventsListSection locale={locale} title={title}>
+          {body}
+        </EventsListSection>
+      );
+    // No title: the shop grid has no heading slot.
     case "products":
       return (
         <ProductsListSection
           locale={locale}
           basePath={basePath}
           currentPage={readPage(searchParams)}
-        />
+        >
+          {body}
+        </ProductsListSection>
       );
   }
 };

--- a/src/components/Pagination/index.test.tsx
+++ b/src/components/Pagination/index.test.tsx
@@ -75,6 +75,21 @@ describe("Pagination", () => {
     expect(html).not.toContain("page=6");
   });
 
+  // A listing block in the same page's body pages by a param of its own.
+  it("carries the rest of the query string across a page move", async () => {
+    const html = await render(
+      <Pagination
+        currentPage={1}
+        totalPages={5}
+        baseUrl="/p/merch"
+        searchParams={{ page: "1", evt_9k3z1: "3" }}
+      />,
+    );
+
+    expect(html).toContain("/p/merch?evt_9k3z1=3&amp;page=0");
+    expect(html).toContain("/p/merch?evt_9k3z1=3&amp;page=2");
+  });
+
   it("renders nothing when there are no pages to move between", async () => {
     await expect(
       render(<Pagination currentPage={0} totalPages={0} baseUrl="/archive" />),

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,8 +1,11 @@
+import type { SearchParams } from "@venuecms/sdk-next";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { ReactNode } from "react";
 
 import { Link } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
+
+import { buildPageHref } from "@/components/utils/searchParams";
 
 /**
  * The prev/next control itself: two arrows and nothing else.
@@ -87,6 +90,8 @@ interface PaginationProps {
   currentPage: number;
   totalPages: number;
   baseUrl: string;
+  /** Carried through, so paging the page does not reset a listing block in its body. */
+  searchParams?: SearchParams;
   className?: string;
 }
 
@@ -94,13 +99,14 @@ export const Pagination = ({
   currentPage,
   totalPages,
   baseUrl,
+  searchParams = {},
   className,
 }: PaginationProps) => {
   if (totalPages < 1) {
     return null; // Don't render pagination if there's only one page or less
   }
 
-  const pageHref = (page: number) => `${baseUrl}?page=${page}`;
+  const pageHref = (page: number) => buildPageHref(baseUrl, searchParams, page);
 
   return (
     <PaginationLinks

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -1,15 +1,3 @@
-/**
- * The pager, which is the only part of this listing that can be wrong quietly.
- *
- * The grid either shows products or does not, and a reader can see which. A
- * pager pointing at the wrong route still renders two working arrows — they
- * just walk the reader off the page they were on, which is what happens to a
- * page typed as the product listing if this component keeps hardcoding /shop.
- *
- * `connection()` is stubbed because the component calls it to opt out of the
- * prerender, and outside a Next request scope it throws. That is not the
- * behaviour under test.
- */
 import { setConfig } from "@venuecms/sdk-next";
 import { NextIntlClientProvider } from "next-intl";
 import type { ReactNode } from "react";
@@ -25,10 +13,8 @@ vi.mock("@/components/ListProduct", () => ({
   ),
 }));
 
-/** Enough products for the endpoint to report more pages after this one. */
 const COUNT = 120;
 
-/** What the products endpoint hands back for a full first page. */
 const PAGE_SIZE = 50;
 
 const render = async (node: ReactNode) => {

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -85,3 +85,18 @@ describe("the products listing pager", () => {
     expect(html).not.toContain("/shop?page=");
   });
 });
+
+describe("the products listing body", () => {
+  it("renders a body it was handed above the products", async () => {
+    const html = await render(
+      <ProductsListContent locale="en" currentPage={0} basePath="/p/merch">
+        <p>Season notes</p>
+      </ProductsListContent>,
+    );
+
+    expect(html.indexOf("Season notes")).toBeGreaterThan(-1);
+    expect(html.indexOf("Season notes")).toBeLessThan(
+      html.indexOf('data-testid="product"'),
+    );
+  });
+});

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -5,6 +5,7 @@ import { renderToReadableStream } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ProductsListContent } from "./ProductsListContent";
+import { ProductsListSection } from "./ProductsListSection";
 
 vi.mock("next/server", () => ({ connection: async () => {} }));
 vi.mock("@/components/ListProduct", () => ({
@@ -12,6 +13,10 @@ vi.mock("@/components/ListProduct", () => ({
     <div data-testid="product">{product.slug}</div>
   ),
 }));
+
+// Containment alone would pass with the body drawn outside the listing, so the
+// assertions read the section that should hold it.
+const listingSection = (html: string) => html.split("<section")[1] ?? "";
 
 const COUNT = 120;
 
@@ -84,19 +89,57 @@ describe("the products listing pager", () => {
     expect(html).toContain("/p/merch?page=2");
     expect(html).not.toContain("/shop?page=");
   });
+
+  // Without this the body's listing block snaps back to its first page.
+  it("keeps a listing block's own param when paging the route", async () => {
+    const html = await render(
+      <ProductsListContent
+        locale="en"
+        currentPage={1}
+        basePath="/p/merch"
+        searchParams={{ page: "1", evt_9k3z1: "3" }}
+      />,
+    );
+
+    expect(html).toContain("/p/merch?evt_9k3z1=3&amp;page=2");
+  });
 });
 
 describe("the products listing body", () => {
   it("renders a body it was handed above the products", async () => {
-    const html = await render(
-      <ProductsListContent locale="en" currentPage={0} basePath="/p/merch">
-        <p>Season notes</p>
-      </ProductsListContent>,
+    const section = listingSection(
+      await render(
+        <ProductsListContent locale="en" currentPage={0} basePath="/p/merch">
+          <p>Season notes</p>
+        </ProductsListContent>,
+      ),
     );
 
-    expect(html.indexOf("Season notes")).toBeGreaterThan(-1);
-    expect(html.indexOf("Season notes")).toBeLessThan(
-      html.indexOf('data-testid="product"'),
+    expect(section.indexOf("Season notes")).toBeGreaterThan(-1);
+    expect(section.indexOf("Season notes")).toBeLessThan(
+      section.indexOf('data-testid="product"'),
     );
+  });
+
+  it("renders no body wrapper for the /shop route, which passes none", async () => {
+    const html = await render(
+      <ProductsListContent locale="en" currentPage={0} basePath="/shop" />,
+    );
+
+    expect(html).not.toContain('class="pb-20"');
+  });
+});
+
+describe("the products listing section", () => {
+  it("hands the body it was given to the content it wraps", async () => {
+    const section = listingSection(
+      await render(
+        <ProductsListSection locale="en" currentPage={0} basePath="/p/merch">
+          <p>Season notes</p>
+        </ProductsListSection>,
+      ),
+    );
+
+    expect(section).toContain("Season notes");
   });
 });

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * The pager, which is the only part of this listing that can be wrong quietly.
+ *
+ * The grid either shows products or does not, and a reader can see which. A
+ * pager pointing at the wrong route still renders two working arrows — they
+ * just walk the reader off the page they were on, which is what happens to a
+ * page typed as the product listing if this component keeps hardcoding /shop.
+ *
+ * `connection()` is stubbed because the component calls it to opt out of the
+ * prerender, and outside a Next request scope it throws. That is not the
+ * behaviour under test.
+ */
+import { setConfig } from "@venuecms/sdk-next";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProductsListContent } from "./ProductsListContent";
+
+vi.mock("next/server", () => ({ connection: async () => {} }));
+vi.mock("@/components/ListProduct", () => ({
+  ListProduct: ({ product }: { product: { slug: string } }) => (
+    <div data-testid="product">{product.slug}</div>
+  ),
+}));
+
+/** Enough products for the endpoint to report more pages after this one. */
+const COUNT = 120;
+
+/** What the products endpoint hands back for a full first page. */
+const PAGE_SIZE = 50;
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(
+    <NextIntlClientProvider locale="en" messages={{}}>
+      {node}
+    </NextIntlClientProvider>,
+  );
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+beforeEach(() => {
+  setConfig({ siteKey: "test-site" });
+
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = input instanceof Request ? input.url : String(input);
+
+    let body: unknown = {
+      id: "site-id",
+      timeZone: "Europe/Berlin",
+      settings: {},
+    };
+
+    if (url.includes("/products")) {
+      body = {
+        records: Array.from({ length: PAGE_SIZE }, (_, i) => ({
+          slug: `p${i}`,
+          localizedContent: [],
+        })),
+        count: COUNT,
+      };
+    } else if (url.includes("/pages")) {
+      body = {
+        id: "page-id",
+        slug: "shop",
+        localizedContent: [{ siteId: "site-id", locale: "en", title: "Shop" }],
+      };
+    }
+
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("the products listing pager", () => {
+  it("pages against the /shop route when that is what rendered it", async () => {
+    const html = await render(
+      <ProductsListContent locale="en" currentPage={0} basePath="/shop" />,
+    );
+
+    expect(html).toContain("/shop?page=1");
+  });
+
+  it("pages against the page it is rendered on, not /shop", async () => {
+    const html = await render(
+      <ProductsListContent locale="en" currentPage={1} basePath="/p/merch" />,
+    );
+
+    expect(html).toContain("/p/merch?page=0");
+    expect(html).toContain("/p/merch?page=2");
+    expect(html).not.toContain("/shop?page=");
+  });
+});

--- a/src/components/ShopPage/ProductsListContent.tsx
+++ b/src/components/ShopPage/ProductsListContent.tsx
@@ -11,9 +11,19 @@ const ITEMS_PER_PAGE = 50;
 export async function ProductsListContent({
   locale,
   currentPage,
+  basePath,
 }: {
   locale: string;
   currentPage: number;
+  /**
+   * The path the pager builds its hrefs against.
+   *
+   * Passed in rather than hardcoded to `/shop` because this listing is no
+   * longer only that route: a page typed as the product listing pages against
+   * its own `/p/<slug>`, and a pager that walked a reader back to `/shop`
+   * would fail silently — the links render, they just leave the page.
+   */
+  basePath: string;
 }) {
   await connection();
 
@@ -68,7 +78,7 @@ export async function ProductsListContent({
         <Pagination
           currentPage={currentPage}
           totalPages={totalPages - 1}
-          baseUrl={`/shop`}
+          baseUrl={basePath}
         />
       ) : null}
     </section>

--- a/src/components/ShopPage/ProductsListContent.tsx
+++ b/src/components/ShopPage/ProductsListContent.tsx
@@ -15,14 +15,7 @@ export async function ProductsListContent({
 }: {
   locale: string;
   currentPage: number;
-  /**
-   * The path the pager builds its hrefs against.
-   *
-   * Passed in rather than hardcoded to `/shop` because this listing is no
-   * longer only that route: a page typed as the product listing pages against
-   * its own `/p/<slug>`, and a pager that walked a reader back to `/shop`
-   * would fail silently — the links render, they just leave the page.
-   */
+  /** Path the pager builds hrefs against; a listing page pages against its own /p/<slug>. */
   basePath: string;
 }) {
   await connection();

--- a/src/components/ShopPage/ProductsListContent.tsx
+++ b/src/components/ShopPage/ProductsListContent.tsx
@@ -12,11 +12,14 @@ export async function ProductsListContent({
   locale,
   currentPage,
   basePath,
+  children,
 }: {
   locale: string;
   currentPage: number;
   /** Path the pager builds hrefs against; a listing page pages against its own /p/<slug>. */
   basePath: string;
+  /** The page's body, above the grid; absent on the `/shop` route. */
+  children?: React.ReactNode;
 }) {
   await connection();
 
@@ -48,6 +51,7 @@ export async function ProductsListContent({
 
   return (
     <section className="py-20">
+      {children ? <div className="pb-20">{children}</div> : null}
       <div className="grid gap-8 pb-20 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
         {topProducts?.length
           ? topProducts.map((product) => (

--- a/src/components/ShopPage/ProductsListContent.tsx
+++ b/src/components/ShopPage/ProductsListContent.tsx
@@ -1,3 +1,4 @@
+import type { SearchParams } from "@venuecms/sdk-next";
 import { getLocalizedContent } from "@venuecms/sdk-next";
 import { getPage, getProducts, getSite } from "@venuecms/sdk-next";
 import { notFound } from "next/navigation";
@@ -12,13 +13,14 @@ export async function ProductsListContent({
   locale,
   currentPage,
   basePath,
+  searchParams,
   children,
 }: {
   locale: string;
   currentPage: number;
   /** Path the pager builds hrefs against; a listing page pages against its own /p/<slug>. */
   basePath: string;
-  /** The page's body, above the grid; absent on the `/shop` route. */
+  searchParams?: SearchParams;
   children?: React.ReactNode;
 }) {
   await connection();
@@ -76,6 +78,7 @@ export async function ProductsListContent({
           currentPage={currentPage}
           totalPages={totalPages - 1}
           baseUrl={basePath}
+          searchParams={searchParams}
         />
       ) : null}
     </section>

--- a/src/components/ShopPage/ProductsListSection.tsx
+++ b/src/components/ShopPage/ProductsListSection.tsx
@@ -1,3 +1,4 @@
+import type { SearchParams } from "@venuecms/sdk-next";
 import { Suspense } from "react";
 
 import { Skeleton } from "@/components/ui/Input/Skeleton";
@@ -37,12 +38,13 @@ export function ProductsListSection({
   locale,
   currentPage,
   basePath,
+  searchParams,
   children,
 }: {
   locale: string;
   currentPage: number;
   basePath: string;
-  /** The page's body, above the grid; absent on the `/shop` route. */
+  searchParams?: SearchParams;
   children?: React.ReactNode;
 }) {
   return (
@@ -52,6 +54,7 @@ export function ProductsListSection({
           locale={locale}
           currentPage={currentPage}
           basePath={basePath}
+          searchParams={searchParams}
         >
           {children}
         </ProductsListContent>

--- a/src/components/ShopPage/ProductsListSection.tsx
+++ b/src/components/ShopPage/ProductsListSection.tsx
@@ -36,14 +36,21 @@ function ProductsListSkeleton() {
 export function ProductsListSection({
   locale,
   currentPage,
+  basePath,
 }: {
   locale: string;
   currentPage: number;
+  /** What the pager pages against. See {@link ProductsListContent}. */
+  basePath: string;
 }) {
   return (
     <ErrorBoundary fallback={<ProductsListError />}>
       <Suspense fallback={<ProductsListSkeleton />}>
-        <ProductsListContent locale={locale} currentPage={currentPage} />
+        <ProductsListContent
+          locale={locale}
+          currentPage={currentPage}
+          basePath={basePath}
+        />
       </Suspense>
     </ErrorBoundary>
   );

--- a/src/components/ShopPage/ProductsListSection.tsx
+++ b/src/components/ShopPage/ProductsListSection.tsx
@@ -37,10 +37,13 @@ export function ProductsListSection({
   locale,
   currentPage,
   basePath,
+  children,
 }: {
   locale: string;
   currentPage: number;
   basePath: string;
+  /** The page's body, above the grid; absent on the `/shop` route. */
+  children?: React.ReactNode;
 }) {
   return (
     <ErrorBoundary fallback={<ProductsListError />}>
@@ -49,7 +52,9 @@ export function ProductsListSection({
           locale={locale}
           currentPage={currentPage}
           basePath={basePath}
-        />
+        >
+          {children}
+        </ProductsListContent>
       </Suspense>
     </ErrorBoundary>
   );

--- a/src/components/ShopPage/ProductsListSection.tsx
+++ b/src/components/ShopPage/ProductsListSection.tsx
@@ -40,7 +40,6 @@ export function ProductsListSection({
 }: {
   locale: string;
   currentPage: number;
-  /** What the pager pages against. See {@link ProductsListContent}. */
   basePath: string;
 }) {
   return (

--- a/src/components/utils/pageContent.test.ts
+++ b/src/components/utils/pageContent.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { hasRenderableContent } from "./pageContent";
+
+const localized = (fields: {
+  content?: string | null;
+  contentJSON?: { [key: string]: unknown } | null;
+}) => ({ siteId: "s1", locale: "en", ...fields });
+
+describe("hasRenderableContent", () => {
+  it("is false without localized content", () => {
+    expect(hasRenderableContent(undefined)).toBe(false);
+  });
+
+  it("is true for a markdown body", () => {
+    expect(hasRenderableContent(localized({ content: "## Notes" }))).toBe(true);
+  });
+
+  it.each([
+    ["an empty markdown body", ""],
+    ["a whitespace-only markdown body", "   \n "],
+  ])("is false for %s", (_label, content) => {
+    expect(hasRenderableContent(localized({ content }))).toBe(false);
+  });
+
+  it("is true for a doc with nodes", () => {
+    expect(
+      hasRenderableContent(
+        localized({
+          contentJSON: {
+            type: "doc",
+            content: [
+              { type: "paragraph", content: [{ type: "text", text: "Hi" }] },
+            ],
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  // The editor saves a doc either way, so the guard reads the nodes, not the key.
+  it.each([
+    ["no nodes", { type: "doc", content: [] }],
+    [
+      "one emptied paragraph",
+      { type: "doc", content: [{ type: "paragraph" }] },
+    ],
+    // Also the shape a doc the editor left serialized presents.
+    ["no node array", { type: "doc" }],
+  ])("is false for a doc with %s", (_label, contentJSON) => {
+    expect(hasRenderableContent(localized({ contentJSON }))).toBe(false);
+  });
+
+  // A node the reader can see, even with no text of its own, is content.
+  it("is true for a doc holding only an image", () => {
+    expect(
+      hasRenderableContent(
+        localized({
+          contentJSON: { type: "doc", content: [{ type: "image" }] },
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/components/utils/pageContent.ts
+++ b/src/components/utils/pageContent.ts
@@ -1,0 +1,32 @@
+import type { LocalizedContent } from "@venuecms/sdk-next";
+
+/**
+ * Whether a body would put anything on screen.
+ *
+ * `contentJSON` is truthy even for a cleared editor, which saves a doc holding
+ * one empty paragraph, so a caller guarding on the field alone spaces around
+ * nothing. Only a paragraph is judged by its children: an image or an embed
+ * carries no text and is still content.
+ */
+export const hasRenderableContent = (content?: LocalizedContent): boolean => {
+  if (content?.content?.trim()) {
+    return true;
+  }
+
+  const nodes = content?.contentJSON?.content;
+
+  if (!Array.isArray(nodes)) {
+    return false;
+  }
+
+  return nodes.some((node) => {
+    const { type, content: children } = (node ?? {}) as {
+      type?: string;
+      content?: unknown;
+    };
+
+    return (
+      type !== "paragraph" || (Array.isArray(children) && children.length > 0)
+    );
+  });
+};

--- a/src/components/utils/pageLayout.test.ts
+++ b/src/components/utils/pageLayout.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { resolvePageListingLayout } from "./pageLayout";
+
+describe("resolvePageListingLayout", () => {
+  it("maps each listing page type this template draws to its listing", () => {
+    expect(resolvePageListingLayout("NEWS")).toBe("news");
+    expect(resolvePageListingLayout("NEWSLIST")).toBe("news");
+    expect(resolvePageListingLayout("EVENTLIST")).toBe("events");
+    expect(resolvePageListingLayout("PRODUCTLIST")).toBe("products");
+  });
+
+  it("leaves an ordinary page on the page layout", () => {
+    expect(resolvePageListingLayout("CONTENT")).toBeNull();
+    expect(resolvePageListingLayout("LINK")).toBeNull();
+  });
+
+  it("leaves a profile listing on the page layout, having no index for it", () => {
+    // Deliberate, not an oversight: this template has no profiles index — only
+    // /artists/<slug> — so a page typed PROFILELIST has nothing to stand in
+    // for. It renders its own content, which is the better of the two failures.
+    expect(resolvePageListingLayout("PROFILELIST")).toBeNull();
+  });
+
+  it("leaves a page type this template has never heard of on the page layout", () => {
+    // A page type added to the CMS after this template shipped arrives here as
+    // a plain string. Falling back to the page layout is what keeps such a page
+    // rendering its own content rather than crashing or blanking.
+    expect(resolvePageListingLayout("SOMETHING_NEW")).toBeNull();
+  });
+});

--- a/src/components/utils/pageLayout.test.ts
+++ b/src/components/utils/pageLayout.test.ts
@@ -16,16 +16,10 @@ describe("resolvePageListingLayout", () => {
   });
 
   it("leaves a profile listing on the page layout, having no index for it", () => {
-    // Deliberate, not an oversight: this template has no profiles index — only
-    // /artists/<slug> — so a page typed PROFILELIST has nothing to stand in
-    // for. It renders its own content, which is the better of the two failures.
     expect(resolvePageListingLayout("PROFILELIST")).toBeNull();
   });
 
   it("leaves a page type this template has never heard of on the page layout", () => {
-    // A page type added to the CMS after this template shipped arrives here as
-    // a plain string. Falling back to the page layout is what keeps such a page
-    // rendering its own content rather than crashing or blanking.
     expect(resolvePageListingLayout("SOMETHING_NEW")).toBeNull();
   });
 });

--- a/src/components/utils/pageLayout.ts
+++ b/src/components/utils/pageLayout.ts
@@ -1,0 +1,35 @@
+/**
+ * Which listing, if any, a page's type stands in for.
+ *
+ * A page can be marked in the CMS as the site's news / events / products index.
+ * Such a page renders that listing rather than its own content, so an author
+ * can put the index anywhere in the page tree — and so the listing looks the
+ * same whether a reader arrives at `/events` or at a page slugged something
+ * else entirely.
+ */
+export type PageListingLayout = "news" | "events" | "products";
+
+/**
+ * Keyed by the CMS's `PAGE_TYPE`, and typed against `string` rather than the
+ * SDK's `Page["type"]` on purpose: that union is generated from the API schema
+ * and still stops at `NEWSLIST`, so naming the list types here would not
+ * compile. A lookup is also what makes the unknown case free — a page type
+ * added to the CMS after this template shipped falls through to the page layout
+ * instead of blanking the page.
+ *
+ * `PROFILELIST` is absent for a different reason: the platform has the type,
+ * but this template has no profiles index to point it at — profiles appear as
+ * `/artists/<slug>` and as a listing block inside content, never as a route of
+ * their own. Such a page keeps its own content until there is one.
+ */
+const LISTING_LAYOUT_BY_PAGE_TYPE: Partial<Record<string, PageListingLayout>> =
+  {
+    NEWS: "news",
+    NEWSLIST: "news",
+    EVENTLIST: "events",
+    PRODUCTLIST: "products",
+  };
+
+export const resolvePageListingLayout = (
+  type: string,
+): PageListingLayout | null => LISTING_LAYOUT_BY_PAGE_TYPE[type] ?? null;

--- a/src/components/utils/pageLayout.ts
+++ b/src/components/utils/pageLayout.ts
@@ -1,27 +1,7 @@
-/**
- * Which listing, if any, a page's type stands in for.
- *
- * A page can be marked in the CMS as the site's news / events / products index.
- * Such a page renders that listing rather than its own content, so an author
- * can put the index anywhere in the page tree — and so the listing looks the
- * same whether a reader arrives at `/events` or at a page slugged something
- * else entirely.
- */
 export type PageListingLayout = "news" | "events" | "products";
 
-/**
- * Keyed by the CMS's `PAGE_TYPE`, and typed against `string` rather than the
- * SDK's `Page["type"]` on purpose: that union is generated from the API schema
- * and still stops at `NEWSLIST`, so naming the list types here would not
- * compile. A lookup is also what makes the unknown case free — a page type
- * added to the CMS after this template shipped falls through to the page layout
- * instead of blanking the page.
- *
- * `PROFILELIST` is absent for a different reason: the platform has the type,
- * but this template has no profiles index to point it at — profiles appear as
- * `/artists/<slug>` and as a listing block inside content, never as a route of
- * their own. Such a page keeps its own content until there is one.
- */
+// Keyed by PAGE_TYPE as `string`: the SDK's Page["type"] union stops at NEWSLIST.
+// PROFILELIST omitted — this template has no profiles index to stand in for.
 const LISTING_LAYOUT_BY_PAGE_TYPE: Partial<Record<string, PageListingLayout>> =
   {
     NEWS: "news",

--- a/src/components/utils/searchParams.test.ts
+++ b/src/components/utils/searchParams.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPageHref } from "./searchParams";
+
+describe("buildPageHref", () => {
+  it("pages against the path it was given", () => {
+    expect(buildPageHref("/p/merch", {}, 2)).toBe("/p/merch?page=2");
+  });
+
+  it("replaces the page it was handed rather than repeating it", () => {
+    expect(buildPageHref("/p/merch", { page: "1" }, 2)).toBe("/p/merch?page=2");
+  });
+
+  // Without this a listing block in the page's body snaps back to page 0.
+  it("carries a listing block's own param through", () => {
+    expect(buildPageHref("/p/merch", { evt_9k3z1: "3" }, 1)).toBe(
+      "/p/merch?evt_9k3z1=3&page=1",
+    );
+  });
+
+  it("keeps every value of a repeated param", () => {
+    expect(buildPageHref("/archive", { tag: ["a", "b"] }, 1)).toBe(
+      "/archive?tag=a&tag=b&page=1",
+    );
+  });
+
+  it("drops a param the URL left empty", () => {
+    expect(buildPageHref("/archive", { tag: undefined }, 1)).toBe(
+      "/archive?page=1",
+    );
+  });
+});

--- a/src/components/utils/searchParams.ts
+++ b/src/components/utils/searchParams.ts
@@ -1,0 +1,29 @@
+import type { SearchParams } from "@venuecms/sdk-next";
+
+/**
+ * A route pager's href, carrying every other param through.
+ *
+ * A listing block in the page's body owns a param of its own, so a pager that
+ * wrote `?page=N` alone would snap that block back to its first page.
+ */
+export const buildPageHref = (
+  basePath: string,
+  searchParams: SearchParams,
+  page: number,
+): string => {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (key === "page" || value === undefined) {
+      continue;
+    }
+
+    for (const entry of Array.isArray(value) ? value : [value]) {
+      params.append(key, entry);
+    }
+  }
+
+  params.set("page", String(page));
+
+  return `${basePath}?${params.toString()}`;
+};

--- a/test/stubs/next-navigation.ts
+++ b/test/stubs/next-navigation.ts
@@ -14,15 +14,7 @@ export const useRouter = () => ({
 
 export const usePathname = () => "/";
 
-/**
- * Next's not-found signal.
- *
- * A route or a server component reaches for this when a read comes back empty,
- * so a test that exercises one has to be able to tell "rendered nothing" from
- * "bailed out". Real `notFound()` throws a framework error the router catches;
- * throwing a recognisable one here keeps that distinction without pulling the
- * router in.
- */
+/** Recognisable throw so a test can tell a bailout from an empty render. */
 export const notFound = (): never => {
   throw new Error("NEXT_NOT_FOUND");
 };

--- a/test/stubs/next-navigation.ts
+++ b/test/stubs/next-navigation.ts
@@ -1,6 +1,6 @@
 /**
  * next-intl's client navigation reaches for `next/navigation`, which pnpm does
- * not link into its isolated tree. Only the two hooks it imports are needed —
+ * not link into its isolated tree. Only the hooks it imports are needed —
  * nothing under test navigates.
  */
 export const useRouter = () => ({
@@ -13,3 +13,16 @@ export const useRouter = () => ({
 });
 
 export const usePathname = () => "/";
+
+/**
+ * Next's not-found signal.
+ *
+ * A route or a server component reaches for this when a read comes back empty,
+ * so a test that exercises one has to be able to tell "rendered nothing" from
+ * "bailed out". Real `notFound()` throws a framework error the router catches;
+ * throwing a recognisable one here keeps that distinction without pulling the
+ * router in.
+ */
+export const notFound = (): never => {
+  throw new Error("NEXT_NOT_FOUND");
+};


### PR DESCRIPTION
A page typed Event Listing or Product Listing now renders that listing instead of the generic page layout, so an author can put the index anywhere in the tree. The events and shop listings move into shared components so the static and page-typed routes cannot drift. A listing page also renders its own body above the records, through VenueContent with the listing-block components, so a listing block embedded in that body renders and paginates.

Fixes a shop pager bug on the way: the pager rebuilt the URL from scratch, dropping a body block's own page param.

Two things a reviewer should know. The body renders inside the listing's Suspense boundary so it stays aligned in the records column; the cost is that it paints with the records rather than the skeleton, and a failed listing fetch drops it too — hoisting it out means restructuring the Section to own the layout chrome, deferred. And #66 renders shop content in the /shop route with renderedStyles and no searchParams, which silently drops listing blocks in that body; it conflicts textually with this branch and is better rewritten onto this path once this lands. #67 removes text-sm but predates PageListing, so the body class here needs a follow-up hunk when it merges.