### PR TITLE
feat(pages): render a profile listing for PROFILELIST pages (VEN-681)

### DIFF
--- a/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
@@ -90,8 +90,15 @@ describe("the page route", () => {
     );
   });
 
-  it("keeps a page typed as a listing this template has no index for", async () => {
-    expect(await renderRoute("PROFILELIST")).toContain(
+  it("renders a profile listing page with its listing", async () => {
+    const html = await renderRoute("PROFILELIST");
+
+    expect(html).not.toContain('data-testid="page-layout"');
+    expect(html).toContain('data-layout="profiles"');
+  });
+
+  it("keeps a page type this template has no listing for on the page layout", async () => {
+    expect(await renderRoute("SOMETHING_NEW")).toContain(
       'data-testid="page-layout"',
     );
   });

--- a/src/app/[siteKey]/[locale]/shop/page.tsx
+++ b/src/app/[siteKey]/[locale]/shop/page.tsx
@@ -16,18 +16,11 @@ const ProductsPage = async ({
   params: Promise<Params>;
   searchParams: Promise<{ page: string }>;
 }) => {
-  const { locale } = await params;
   await setupSSR({ params });
 
   const currentPage = parseInt((await searchParams)?.page as string, 10) || 0;
 
-  return (
-    <ProductsListSection
-      locale={locale}
-      currentPage={currentPage}
-      basePath="/shop"
-    />
-  );
+  return <ProductsListSection currentPage={currentPage} basePath="/shop" />;
 };
 
 export default ProductsPage;

--- a/src/components/EventsPage/EventsListContent.test.tsx
+++ b/src/components/EventsPage/EventsListContent.test.tsx
@@ -4,7 +4,6 @@ import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { EventsListContent } from "./EventsListContent";
 import { EventsListSection } from "./EventsListSection";
 
 vi.mock("next/server", () => ({ connection: async () => {} }));
@@ -18,40 +17,66 @@ const render = async (node: ReactNode) => {
     <NextIntlClientProvider locale="en" messages={{}}>
       {node}
     </NextIntlClientProvider>,
+    // The list's boundary is expected to catch a failed read; without this the
+    // recoverable error still reaches the console and reads as a test error.
+    { onError: () => {} },
   );
   await stream.allReady;
   return new Response(stream).text();
 };
 
+const requestedUrls = () =>
+  vi
+    .mocked(globalThis.fetch)
+    .mock.calls.map(([input]) =>
+      input instanceof Request ? input.url : String(input),
+    );
+
+/** The title on the "events" page record, or null for a locale saved without one. */
+let recordTitle: string | null = "Upcoming Events";
+let siteReadFails = false;
+
 beforeEach(() => {
   setConfig({ siteKey: "test-site" });
+  recordTitle = "Upcoming Events";
+  siteReadFails = false;
 
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = input instanceof Request ? input.url : String(input);
 
-    let body: unknown = {
-      id: "site-id",
-      timeZone: "Europe/Berlin",
-      settings: {},
-    };
-
     // Pages first: /pages/events would otherwise match the events branch.
     if (url.includes("/pages")) {
-      body = {
-        id: "page-id",
-        slug: "events",
-        localizedContent: [
-          { siteId: "site-id", locale: "en", title: "Upcoming Events" },
-        ],
-      };
-    } else if (url.includes("/events")) {
-      body = { records: [], count: 0 };
+      return new Response(
+        JSON.stringify({
+          id: "page-id",
+          slug: "events",
+          localizedContent: [
+            { siteId: "site-id", locale: "en", title: recordTitle },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
     }
 
-    return new Response(JSON.stringify(body), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
+    if (url.includes("/events")) {
+      return new Response(JSON.stringify({ records: [], count: 0 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (siteReadFails) {
+      return new Response("upstream is down", { status: 500 });
+    }
+
+    return new Response(
+      JSON.stringify({
+        id: "site-id",
+        timeZone: "Europe/Berlin",
+        settings: {},
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
   });
 });
 
@@ -61,46 +86,45 @@ afterEach(() => {
 
 describe("the events listing heading", () => {
   it("reads the /events page record when no title was handed to it", async () => {
-    const html = await render(<EventsListContent locale="en" />);
-
-    expect(html).toContain("Upcoming Events");
+    expect(await render(<EventsListSection locale="en" />)).toContain(
+      "Upcoming Events",
+    );
   });
 
   it("prefers the title it was given, and does not read the page record", async () => {
     const html = await render(
-      <EventsListContent locale="en" title="What's On" />,
+      <EventsListSection locale="en" title="What's On" />,
     );
 
     expect(html).toContain("What&#x27;s On");
     expect(html).not.toContain("Upcoming Events");
-
-    const requested = vi
-      .mocked(globalThis.fetch)
-      .mock.calls.map(([input]) =>
-        input instanceof Request ? input.url : String(input),
-      );
-
-    expect(requested.some((url) => url.includes("/pages"))).toBe(false);
+    expect(requestedUrls().some((url) => url.includes("/pages"))).toBe(false);
   });
 
-  it("renders a body it was handed above the events", async () => {
-    const column = columnRight(
-      await render(
-        <EventsListContent locale="en" title="What's On">
-          <p>Season notes</p>
-        </EventsListContent>,
-      ),
-    );
+  // A locale saved without a title yields "", not undefined. Reading absence
+  // rather than emptiness would take "" for a title and draw a blank column —
+  // and would skip the page read whose answer it then ignored.
+  it.each([
+    ["an empty title", ""],
+    ["a whitespace-only title", "   "],
+  ])("reads the page record given %s", async (_label, title) => {
+    const html = await render(<EventsListSection locale="en" title={title} />);
 
-    expect(column.indexOf("Season notes")).toBeGreaterThan(-1);
-    expect(column.indexOf("Season notes")).toBeLessThan(
-      column.indexOf("No events found"),
+    expect(html).toContain("Upcoming Events");
+  });
+
+  // And the record's own title can be blank the same way.
+  it("falls back to a heading of its own when the record has none", async () => {
+    recordTitle = "";
+
+    expect(await render(<EventsListSection locale="en" />)).toContain(
+      "upcoming events",
     );
   });
 });
 
-describe("the events listing section", () => {
-  it("hands the body it was given to the content it wraps", async () => {
+describe("the events listing body", () => {
+  it("renders a body it was handed above the events", async () => {
     const column = columnRight(
       await render(
         <EventsListSection locale="en" title="What's On">
@@ -109,6 +133,31 @@ describe("the events listing section", () => {
       ),
     );
 
-    expect(column).toContain("Season notes");
+    expect(column.indexOf("Season notes")).toBeGreaterThan(-1);
+    expect(column.indexOf("Season notes")).toBeLessThan(
+      column.indexOf("No events found"),
+    );
+  });
+
+  // The heading and the body cost no request of their own, so they sit outside
+  // the boundaries: a failed list read has no business taking an author's prose
+  // or the page's title down with it.
+  //
+  // Asserted on what survives rather than on the error copy: the boundary that
+  // catches the bailout is a client component, and React hands a suspended
+  // boundary's error to the client rather than running its fallback in SSR.
+  it("keeps the title and the body when the list fails", async () => {
+    siteReadFails = true;
+
+    const html = await render(
+      <EventsListSection locale="en" title="What's On">
+        <p>Season notes</p>
+      </EventsListSection>,
+    );
+
+    expect(html).toContain("What&#x27;s On");
+    expect(html).toContain("Season notes");
+    // And does not pass the failure off as a listing that is merely empty.
+    expect(html).not.toContain("No events found");
   });
 });

--- a/src/components/EventsPage/EventsListContent.tsx
+++ b/src/components/EventsPage/EventsListContent.tsx
@@ -4,24 +4,36 @@ import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
 import { EventsList, ListEvent } from "@/components/EventList";
-import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
 
-export async function EventsListContent({
-  locale,
-  title,
-  children,
-}: {
-  locale: string;
-  /** Heading; a listing page passes its own, else the "events" record is read for one. */
-  title?: string;
-  children?: React.ReactNode;
-}) {
+/**
+ * The heading a listing brings no title of its own: the "events" page record's.
+ *
+ * Its own component, and so its own boundary, because it is the one part of the
+ * left column that costs a request. A listing page passes its title straight in
+ * and this never renders.
+ */
+export async function EventsHeading({ locale }: { locale: string }) {
+  const { data: page } = await getPage({ slug: "events" });
+
+  const recordTitle = page
+    ? getLocalizedContent(page.localizedContent, locale).content.title
+    : null;
+
+  // Emptiness, not absence: a locale saved without a title yields "", which
+  // would otherwise draw a blank heading in place of the fallback.
+  return recordTitle?.trim() ? recordTitle : "upcoming events";
+}
+
+/**
+ * The records half of the events listing. Draws only the list: the frame, the
+ * heading and any page body live in `EventsListSection`, above the Suspense
+ * boundary, so none of them wait on this fetch or vanish with it.
+ */
+export async function EventsListContent() {
   await connection();
 
-  const [{ data: events }, { data: page }, { data: site }] = await Promise.all([
+  const [{ data: events }, { data: site }] = await Promise.all([
     getEvents({ limit: 60, upcoming: true }),
-    // Read for the title only, so skipped when the caller brought one.
-    title ? { data: null } : getPage({ slug: "events" }),
     getSite(),
   ]);
 
@@ -29,29 +41,13 @@ export async function EventsListContent({
     notFound();
   }
 
-  const pageTitle =
-    title ??
-    (page
-      ? getLocalizedContent(page.localizedContent, locale).content.title
-      : "upcoming events");
-
-  return (
-    <TwoColumnLayout>
-      <ColumnLeft className="text-sm text-secondary">
-        <p className="pb-8 text-primary">{pageTitle}</p>
-      </ColumnLeft>
-      <ColumnRight>
-        {children}
-        {events?.records.length ? (
-          <EventsList className="gap-y-12">
-            {events.records.map((event) => (
-              <ListEvent key={event.id} event={event} site={site} withImage />
-            ))}
-          </EventsList>
-        ) : (
-          "No events found"
-        )}
-      </ColumnRight>
-    </TwoColumnLayout>
+  return events?.records.length ? (
+    <EventsList className="gap-y-12">
+      {events.records.map((event) => (
+        <ListEvent key={event.id} event={event} site={site} withImage />
+      ))}
+    </EventsList>
+  ) : (
+    "No events found"
   );
 }

--- a/src/components/EventsPage/EventsListContent.tsx
+++ b/src/components/EventsPage/EventsListContent.tsx
@@ -2,17 +2,30 @@ import { getLocalizedContent } from "@venuecms/sdk-next";
 import { getEvents, getPage, getSite } from "@venuecms/sdk-next";
 import { notFound } from "next/navigation";
 import { connection } from "next/server";
+import type { ReactNode } from "react";
 
 import { EventsList, ListEvent } from "@/components/EventList";
+
+/** The one markup both spellings of the heading render, so they cannot drift. */
+export function EventsHeadingText({ children }: { children: ReactNode }) {
+  return <p className="pb-8 text-primary">{children}</p>;
+}
 
 /**
  * The heading a listing brings no title of its own: the "events" page record's.
  *
- * Its own component, and so its own boundary, because it is the one part of the
- * left column that costs a request. A listing page passes its title straight in
- * and this never renders.
+ * Its own component, and so its own boundaries, because it is the one part of
+ * the left column that costs a request. A listing page passes its title
+ * straight in and this never renders.
+ *
+ * It draws the whole `<p>` rather than returning bare text so that the pending
+ * and failed spellings of this slot are block elements too — a `<div>` skeleton
+ * inside the `<p>` would be invalid nesting, and the parser relocating it out
+ * breaks the sibling walk React uses to swap a resolved boundary in.
  */
 export async function EventsHeading({ locale }: { locale: string }) {
+  await connection();
+
   const { data: page } = await getPage({ slug: "events" });
 
   const recordTitle = page
@@ -21,7 +34,11 @@ export async function EventsHeading({ locale }: { locale: string }) {
 
   // Emptiness, not absence: a locale saved without a title yields "", which
   // would otherwise draw a blank heading in place of the fallback.
-  return recordTitle?.trim() ? recordTitle : "upcoming events";
+  return (
+    <EventsHeadingText>
+      {recordTitle?.trim() ? recordTitle : "upcoming events"}
+    </EventsHeadingText>
+  );
 }
 
 /**

--- a/src/components/EventsPage/EventsListSection.tsx
+++ b/src/components/EventsPage/EventsListSection.tsx
@@ -5,63 +5,77 @@ import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
 import { Skeleton } from "@/components/ui/Input/Skeleton";
 import { ErrorBoundary } from "@/components/utils/ErrorBoundary";
 
-import { EventsListContent } from "./EventsListContent";
+import { EventsHeading, EventsListContent } from "./EventsListContent";
 
 function EventsListError() {
   return (
-    <TwoColumnLayout>
-      <ColumnLeft className="text-sm text-secondary" />
-      <ColumnRight>
-        <p className="text-secondary">
-          Unable to load events. Please try refreshing the page.
-        </p>
-      </ColumnRight>
-    </TwoColumnLayout>
+    <p className="text-secondary">
+      Unable to load events. Please try refreshing the page.
+    </p>
   );
 }
 
 function EventsListSkeleton() {
   return (
-    <TwoColumnLayout>
-      <ColumnLeft className="text-sm text-secondary">
-        <div className="pb-8">
-          <Skeleton className="w-32" />
+    <EventsList className="gap-y-12">
+      {[1, 2, 3, 4, 5, 6].map((i) => (
+        <div key={i} className="flex flex-col gap-3 pb-8">
+          <Skeleton className="aspect-video w-full sm:w-80" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="w-32" />
+            <Skeleton className="w-48" />
+            <Skeleton className="w-24" />
+          </div>
         </div>
-      </ColumnLeft>
-      <ColumnRight>
-        <EventsList className="gap-y-12">
-          {[1, 2, 3, 4, 5, 6].map((i) => (
-            <div key={i} className="flex flex-col gap-3 pb-8">
-              <Skeleton className="aspect-video w-full sm:w-80" />
-              <div className="flex flex-col gap-1">
-                <Skeleton className="w-32" />
-                <Skeleton className="w-48" />
-                <Skeleton className="w-24" />
-              </div>
-            </div>
-          ))}
-        </EventsList>
-      </ColumnRight>
-    </TwoColumnLayout>
+      ))}
+    </EventsList>
   );
 }
 
+/**
+ * The frame of the events listing, shared by /events and by an EVENTLIST page.
+ *
+ * The page's own body sits *outside* the boundaries on purpose. It is already
+ * in hand and costs no request, so putting it under the Suspense would hide
+ * readable content behind the records' skeleton and shift the layout when they
+ * resolved, and putting it under the ErrorBoundary would delete an author's
+ * prose because an unrelated fetch failed. The heading is the same, except when
+ * it has to be read from the "events" record — then it gets a boundary of its
+ * own rather than sharing the records'.
+ */
 export function EventsListSection({
   locale,
   title,
   children,
 }: {
   locale: string;
+  /** Heading; a listing page passes its own, else the "events" record is read for one. */
   title?: string;
   children?: React.ReactNode;
 }) {
+  // Emptiness, not absence: a page saved without a title for this locale yields
+  // "", and `??` would keep it and draw an empty heading column.
+  const ownTitle = title?.trim() ? title : null;
+
   return (
-    <ErrorBoundary fallback={<EventsListError />}>
-      <Suspense fallback={<EventsListSkeleton />}>
-        <EventsListContent locale={locale} title={title}>
-          {children}
-        </EventsListContent>
-      </Suspense>
-    </ErrorBoundary>
+    <TwoColumnLayout>
+      <ColumnLeft className="text-sm text-secondary">
+        <p className="pb-8 text-primary">
+          {ownTitle ?? (
+            <Suspense fallback={<Skeleton className="w-32" />}>
+              <EventsHeading locale={locale} />
+            </Suspense>
+          )}
+        </p>
+      </ColumnLeft>
+      <ColumnRight>
+        {children}
+        <ErrorBoundary fallback={<EventsListError />}>
+          <Suspense fallback={<EventsListSkeleton />}>
+            <EventsListContent />
+          </Suspense>
+        </ErrorBoundary>
+      </ColumnRight>
+    </TwoColumnLayout>
   );
 }

--- a/src/components/EventsPage/EventsListSection.tsx
+++ b/src/components/EventsPage/EventsListSection.tsx
@@ -5,7 +5,11 @@ import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
 import { Skeleton } from "@/components/ui/Input/Skeleton";
 import { ErrorBoundary } from "@/components/utils/ErrorBoundary";
 
-import { EventsHeading, EventsListContent } from "./EventsListContent";
+import {
+  EventsHeading,
+  EventsHeadingText,
+  EventsListContent,
+} from "./EventsListContent";
 
 function EventsListError() {
   return (
@@ -60,13 +64,26 @@ export function EventsListSection({
   return (
     <TwoColumnLayout>
       <ColumnLeft className="text-sm text-secondary">
-        <p className="pb-8 text-primary">
-          {ownTitle ?? (
-            <Suspense fallback={<Skeleton className="w-32" />}>
+        {ownTitle ? (
+          <EventsHeadingText>{ownTitle}</EventsHeadingText>
+        ) : (
+          // Boundaries of its own, not the records': this read is the only one
+          // the left column makes, and an unreadable title has no business
+          // either waiting on the list or taking the route down with it.
+          <ErrorBoundary
+            fallback={<EventsHeadingText>upcoming events</EventsHeadingText>}
+          >
+            <Suspense
+              fallback={
+                <div className="pb-8">
+                  <Skeleton className="w-32" />
+                </div>
+              }
+            >
               <EventsHeading locale={locale} />
             </Suspense>
-          )}
-        </p>
+          </ErrorBoundary>
+        )}
       </ColumnLeft>
       <ColumnRight>
         {children}

--- a/src/components/ListingBlock/blocks.tsx
+++ b/src/components/ListingBlock/blocks.tsx
@@ -30,8 +30,7 @@ import type { ListingProps } from "@venuecms/sdk-next";
 import { EventsList, ListEvent } from "@/components/EventList";
 import { ListProduct } from "@/components/ListProduct";
 import { ListPage, PagesList } from "@/components/PageList";
-import { ProfileCompact } from "@/components/ProfileCompact";
-import { TwoSubColumnLayout } from "@/components/layout";
+import { ProfilesList } from "@/components/ProfileList";
 import {
   resolveNewsArticleHref,
   resolvePageHref,
@@ -155,10 +154,6 @@ export const ProfileListingBlock = ({
   pagination,
 }: ListingProps<"profileListing">) => (
   <PaginatedListing pagination={pagination} records={records} label="Profiles">
-    <TwoSubColumnLayout className="py-4">
-      {records.map((profile) => (
-        <ProfileCompact key={profile.slug} profile={profile} />
-      ))}
-    </TwoSubColumnLayout>
+    <ProfilesList profiles={records} className="py-4" />
   </PaginatedListing>
 );

--- a/src/components/PageListing/boundaries.test.tsx
+++ b/src/components/PageListing/boundaries.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Where a listing page's heading and body sit relative to its records' error
+ * boundary — the one thing every one of these views had to get right, and the
+ * one thing a plain SSR render cannot see.
+ *
+ * `ErrorBoundary` is a client component, and React hands a suspended boundary's
+ * error to the client rather than running its fallback while streaming. So a
+ * body nested *inside* the boundary still appears in the server output, and an
+ * assertion on that output passes whether the body is inside or outside it —
+ * which is exactly how the first spelling of these tests passed against the bug
+ * they were written to catch.
+ *
+ * Here the boundary is replaced by one that always draws its fallback, which is
+ * what "the records failed" looks like. Whatever still renders is what genuinely
+ * sits outside it, and a body that moves back under the boundary fails these.
+ */
+import type { SearchParams } from "@venuecms/sdk-next";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { EventsListSection } from "@/components/EventsPage";
+import { ProfilesListSection } from "@/components/ProfilesPage";
+import { ProductsListSection } from "@/components/ShopPage";
+
+vi.mock("next/server", () => ({ connection: async () => {} }));
+
+vi.mock("@/components/utils/ErrorBoundary", () => ({
+  ErrorBoundary: ({ fallback }: { fallback: ReactNode }) => fallback,
+}));
+
+// Nothing should reach the network: every records component this file renders
+// sits under the stubbed boundary and is replaced by its fallback.
+const fetchSpy = vi
+  .spyOn(globalThis, "fetch")
+  .mockImplementation(async () => new Response("{}"));
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(
+    <NextIntlClientProvider locale="en" messages={{}}>
+      {node}
+    </NextIntlClientProvider>,
+  );
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+const sections: Array<
+  [string, (props: { children: ReactNode }) => ReactNode, string]
+> = [
+  [
+    "events",
+    ({ children }) => (
+      <EventsListSection locale="en" title="What's On">
+        {children}
+      </EventsListSection>
+    ),
+    "What&#x27;s On",
+  ],
+  [
+    "profiles",
+    ({ children }) => (
+      <ProfilesListSection title="Artists" basePath="/p/roster" currentPage={0}>
+        {children}
+      </ProfilesListSection>
+    ),
+    "Artists",
+  ],
+];
+
+describe("a listing whose records failed", () => {
+  it.each(sections)(
+    "keeps the %s heading and body",
+    async (_name, Section, heading) => {
+      const html = await render(<Section>{<p>Season notes</p>}</Section>);
+
+      expect(html).toContain(heading);
+      expect(html).toContain("Season notes");
+    },
+  );
+
+  // The shop grid has no heading slot, so only its body is at stake.
+  it("keeps the products body", async () => {
+    const html = await render(
+      <ProductsListSection currentPage={0} basePath="/p/merch">
+        <p>Season notes</p>
+      </ProductsListSection>,
+    );
+
+    expect(html).toContain("Season notes");
+  });
+
+  it("draws each listing's own failure message in place of its records", async () => {
+    const searchParams: SearchParams = {};
+
+    expect(
+      await render(
+        <ProfilesListSection
+          title="Artists"
+          basePath="/p/roster"
+          currentPage={0}
+          searchParams={searchParams}
+        />,
+      ),
+    ).toContain("Unable to load artists");
+
+    expect(
+      await render(<EventsListSection locale="en" title="What's On" />),
+    ).toContain("Unable to load events");
+
+    expect(
+      await render(<ProductsListSection currentPage={0} basePath="/shop" />),
+    ).toContain("Unable to load products");
+  });
+
+  it("asks the network for nothing once the records are out of the way", () => {
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -140,16 +140,23 @@ describe("PageListing", () => {
     expect(html).not.toContain("data-title");
   });
 
-  it("pages the products listing against the page it is rendered on", async () => {
-    const html = await renderListing({
-      layout: "products",
-      basePath: "/p/merch",
-      searchParams: { page: "2" },
-    });
+  it.each([
+    ["products", "products-view"],
+    ["profiles", "profiles-view"],
+  ] as const)(
+    "pages the %s listing against the page it is rendered on",
+    async (layout, testId) => {
+      const html = await renderListing({
+        layout,
+        basePath: "/p/merch",
+        searchParams: { page: "2" },
+      });
 
-    expect(html).toContain('data-base-path="/p/merch"');
-    expect(html).toContain('data-current-page="2"');
-  });
+      expect(html).toContain(`data-testid="${testId}"`);
+      expect(html).toContain('data-base-path="/p/merch"');
+      expect(html).toContain('data-current-page="2"');
+    },
+  );
 
   it("takes the first of a repeated page param, as a route would", async () => {
     const html = await renderListing({

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -69,6 +69,9 @@ vi.mock("@/components/EventsPage", () => ({
 vi.mock("@/components/ShopPage", () => ({
   ProductsListSection: stub("products-view"),
 }));
+vi.mock("@/components/ProfilesPage", () => ({
+  ProfilesListSection: stub("profiles-view"),
+}));
 vi.mock("@/components/ListingBlock", () => ({
   contentComponents: { p: "prose" },
 }));
@@ -109,6 +112,7 @@ describe("PageListing", () => {
     ["news", "news-view"],
     ["events", "events-view"],
     ["products", "products-view"],
+    ["profiles", "profiles-view"],
   ] as const)("renders the %s listing", async (layout, testId) => {
     expect(await renderListing({ layout })).toContain(
       `data-testid="${testId}"`,
@@ -118,6 +122,7 @@ describe("PageListing", () => {
   it.each([
     ["news", "news-view"],
     ["events", "events-view"],
+    ["profiles", "profiles-view"],
   ] as const)(
     "gives the %s listing the page's own title",
     async (layout, testId) => {
@@ -179,6 +184,7 @@ describe("PageListing", () => {
   it.each([
     ["events", "events-view"],
     ["products", "products-view"],
+    ["profiles", "profiles-view"],
   ] as const)(
     "renders the page's own content inside the %s listing",
     async (layout, testId) => {

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -57,7 +57,6 @@ export const PageListing = ({
     case "products":
       return (
         <ProductsListSection
-          locale={locale}
           basePath={basePath}
           currentPage={readPage(searchParams)}
           searchParams={searchParams}

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -81,8 +81,13 @@ export const PageListing = ({
     // The events frame, which is also the archive's: with no /profiles route to
     // mirror, the index layout this template already uses is the one to match.
     case "profiles":
-      return (
-        <ProfilesListSection title={title}>{body}</ProfilesListSection>
-      );
+      return <ProfilesListSection title={title}>{body}</ProfilesListSection>;
   }
+
+  // A layout added to the union without a case above is a compile error here
+  // rather than a page that renders nothing: React accepts an undefined return,
+  // so falling off this switch would be silent at runtime and at typecheck.
+  layout satisfies never;
+
+  return null;
 };

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -1,7 +1,6 @@
 /** The listing a page *is*, not `PageListingBlock`, which is a listing of pages. */
 import {
   type LocalizedContent,
-  MAX_PAGE,
   type SearchParams,
   VenueContent,
 } from "@venuecms/sdk-next";
@@ -13,19 +12,7 @@ import { ProfilesListSection } from "@/components/ProfilesPage";
 import { ProductsListSection } from "@/components/ShopPage";
 import { hasRenderableContent } from "@/components/utils/pageContent";
 import type { PageListingLayout } from "@/components/utils/pageLayout";
-
-// Duplicates VEN-514's readPage (#69) on purpose; drop when that lands.
-const readPage = (searchParams: SearchParams): number => {
-  const raw = searchParams.page;
-  const value = Array.isArray(raw) ? raw[0] : raw;
-
-  // Digits only: Number() reads "1e3" as the deepest offset scan the endpoint allows.
-  if (typeof value !== "string" || !/^\d+$/.test(value)) {
-    return 0;
-  }
-
-  return Math.min(Number(value), MAX_PAGE);
-};
+import { readPage } from "@/components/utils/searchParams";
 
 export const PageListing = ({
   layout,

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -9,6 +9,7 @@ import {
 import { EventsListSection } from "@/components/EventsPage";
 import { contentComponents } from "@/components/ListingBlock";
 import { NewsView } from "@/components/News";
+import { ProfilesListSection } from "@/components/ProfilesPage";
 import { ProductsListSection } from "@/components/ShopPage";
 import { hasRenderableContent } from "@/components/utils/pageContent";
 import type { PageListingLayout } from "@/components/utils/pageLayout";
@@ -76,6 +77,12 @@ export const PageListing = ({
         >
           {body}
         </ProductsListSection>
+      );
+    // The events frame, which is also the archive's: with no /profiles route to
+    // mirror, the index layout this template already uses is the one to match.
+    case "profiles":
+      return (
+        <ProfilesListSection title={title}>{body}</ProfilesListSection>
       );
   }
 };

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -81,7 +81,16 @@ export const PageListing = ({
     // The events frame, which is also the archive's: with no /profiles route to
     // mirror, the index layout this template already uses is the one to match.
     case "profiles":
-      return <ProfilesListSection title={title}>{body}</ProfilesListSection>;
+      return (
+        <ProfilesListSection
+          title={title}
+          basePath={basePath}
+          currentPage={readPage(searchParams)}
+          searchParams={searchParams}
+        >
+          {body}
+        </ProfilesListSection>
+      );
   }
 
   // A layout added to the union without a case above is a compile error here

--- a/src/components/ProfileList/index.test.tsx
+++ b/src/components/ProfileList/index.test.tsx
@@ -1,0 +1,55 @@
+import type { ListingRecords } from "@venuecms/sdk-next";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ProfileListingBlock } from "@/components/ListingBlock/blocks";
+
+import { ProfilesList } from "./index";
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(
+    <NextIntlClientProvider locale="en" messages={{}}>
+      {node}
+    </NextIntlClientProvider>,
+  );
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+const profiles = (...titles: string[]): ListingRecords["profileListing"] =>
+  titles.map((title, index) => ({
+    siteId: "site-id",
+    slug: `profile-${index}`,
+    localizedContent: [{ siteId: "site-id", locale: "en", title }],
+  }));
+
+describe("ProfilesList", () => {
+  it("draws a card per profile", async () => {
+    const html = await render(
+      <ProfilesList profiles={profiles("An artist", "Another artist")} />,
+    );
+
+    expect(html).toContain("An artist");
+    expect(html).toContain("Another artist");
+    expect(html).toContain("/artists/profile-0");
+  });
+
+  it("renders nothing but the grid for no profiles", async () => {
+    expect(await render(<ProfilesList profiles={[]} />)).not.toContain("<a");
+  });
+
+  // Asserted against the shared list rather than its class names: the point of
+  // extracting it is that the profile listing page and the content block cannot
+  // drift, and comparing markup is what catches one of them growing a wrapper.
+  it("is what the profile listing block draws", async () => {
+    const records = profiles("An artist", "Another artist");
+
+    expect(
+      await render(
+        <ProfileListingBlock records={records} site={null} pagination={null} />,
+      ),
+    ).toBe(await render(<ProfilesList profiles={records} className="py-4" />));
+  });
+});

--- a/src/components/ProfileList/index.tsx
+++ b/src/components/ProfileList/index.tsx
@@ -1,0 +1,26 @@
+import type { Profile } from "@venuecms/sdk-next";
+
+import { ProfileCompact } from "@/components/ProfileCompact";
+import { TwoSubColumnLayout } from "@/components/layout";
+
+/**
+ * The grid of profile cards, shared by the profile listing page and the profile
+ * listing block, so a page typed `PROFILELIST` and a `profileListing` block in
+ * someone's prose cannot end up drawing the same records two different ways.
+ *
+ * The sibling of `EventsList` for events; a plain function of the records it is
+ * handed, and the one list that needs no `site` to draw.
+ */
+export const ProfilesList = ({
+  profiles,
+  className,
+}: {
+  profiles: readonly Profile[];
+  className?: string;
+}) => (
+  <TwoSubColumnLayout className={className}>
+    {profiles.map((profile) => (
+      <ProfileCompact key={profile.slug} profile={profile} />
+    ))}
+  </TwoSubColumnLayout>
+);

--- a/src/components/ProfileList/index.tsx
+++ b/src/components/ProfileList/index.tsx
@@ -4,9 +4,14 @@ import { ProfileCompact } from "@/components/ProfileCompact";
 import { TwoSubColumnLayout } from "@/components/layout";
 
 /**
- * The grid of profile cards, shared by the profile listing page and the profile
- * listing block, so a page typed `PROFILELIST` and a `profileListing` block in
- * someone's prose cannot end up drawing the same records two different ways.
+ * The grid of profile cards, shared by the profile listing page and the
+ * `profileListing` content block so those two cannot draw the same records two
+ * different ways.
+ *
+ * Not yet shared by the three grids that render a *record's* attached artists —
+ * `Page`, `Event` and `Product` each still inline this markup. They are the
+ * same grid and should move here, but that is a change to pages this branch
+ * does not otherwise touch, and one no test here would catch regressing.
  *
  * The sibling of `EventsList` for events; a plain function of the records it is
  * handed, and the one list that needs no `site` to draw.

--- a/src/components/ProfilesPage/ProfilesListContent.test.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.test.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ProfilesListContent } from "./ProfilesListContent";
+import { PROFILES_PER_PAGE, ProfilesListContent } from "./ProfilesListContent";
 import { ProfilesListSection } from "./ProfilesListSection";
 
 vi.mock("next/server", () => ({ connection: async () => {} }));
@@ -38,6 +38,17 @@ const aProfile = (title: string) => ({
   slug: title.toLowerCase().replace(/\s+/g, "-"),
   localizedContent: [{ siteId: "site-id", locale: "en", title }],
 });
+
+/** A page of the roster `n` records long, to page off the end of. */
+const aRoster = (n: number) =>
+  Array.from({ length: n }, (_, i) => aProfile(`Artist ${i}`));
+
+const renderRoster = (
+  props: Partial<Parameters<typeof ProfilesListSection>[0]> = {},
+) =>
+  render(
+    <ProfilesListSection basePath="/p/roster" currentPage={0} {...props} />,
+  );
 
 let profileRecords: Array<Record<string, unknown>> = [];
 let profilesReadFails = false;
@@ -81,16 +92,14 @@ describe("the profiles listing", () => {
   it("draws the profiles the endpoint returned", async () => {
     profileRecords = [aProfile("An Artist")];
 
-    const html = await render(<ProfilesListSection title="Artists" />);
+    const html = await renderRoster({ title: "Artists" });
 
     expect(html).toContain("An Artist");
     expect(html).toContain("/artists/an-artist");
   });
 
   it("heads itself with the listing page's own title", async () => {
-    expect(await render(<ProfilesListSection title="Roster" />)).toContain(
-      "Roster",
-    );
+    expect(await renderRoster({ title: "Roster" })).toContain("Roster");
   });
 
   // Unlike events and shop, this template has no /profiles route and so no page
@@ -102,14 +111,14 @@ describe("the profiles listing", () => {
     ["an empty title", ""],
     ["a whitespace-only title", "   "],
   ])("falls back to a heading of its own given %s", async (_label, title) => {
-    const html = await render(<ProfilesListSection title={title} />);
+    const html = await renderRoster({ title });
 
     expect(html).toContain("artists");
     expect(requestedUrls().some((url) => url.includes("/pages"))).toBe(false);
   });
 
   it("says so when there are no profiles", async () => {
-    expect(await render(<ProfilesListSection title="Artists" />)).toContain(
+    expect(await renderRoster({ title: "Artists" })).toContain(
       "No artists found",
     );
   });
@@ -122,15 +131,15 @@ describe("the profiles listing", () => {
   it("fails loudly rather than reporting an outage as an empty roster", async () => {
     profilesReadFails = true;
 
-    await expect(ProfilesListContent()).rejects.toThrow(
-      "The profiles endpoint could not be read.",
-    );
+    await expect(
+      ProfilesListContent({ basePath: "/p/roster", currentPage: 0 }),
+    ).rejects.toThrow("The profiles endpoint could not be read.");
   });
 
   // A profile card needs no site, so asking for one would only add a request
   // that a failed read could then 404 the whole page on.
   it("reads no site", async () => {
-    await render(<ProfilesListSection title="Artists" />);
+    await renderRoster({ title: "Artists" });
 
     expect(requestedUrls().every((url) => url.includes("/profiles"))).toBe(
       true,
@@ -141,7 +150,7 @@ describe("the profiles listing", () => {
   // Sending one here would order the same roster differently on the two
   // surfaces the shared `ProfilesList` exists to keep identical.
   it("orders the roster the way a content block does", async () => {
-    await render(<ProfilesListSection title="Artists" />);
+    await renderRoster({ title: "Artists" });
 
     const query = new URL(requestedUrls()[0]).searchParams;
 
@@ -153,11 +162,10 @@ describe("the profiles listing", () => {
     profileRecords = [aProfile("An Artist")];
 
     const column = columnRight(
-      await render(
-        <ProfilesListSection title="Artists">
-          <p>Roster notes</p>
-        </ProfilesListSection>,
-      ),
+      await renderRoster({
+        title: "Artists",
+        children: <p>Roster notes</p>,
+      }),
     );
 
     expect(column.indexOf("Roster notes")).toBeGreaterThan(-1);
@@ -172,15 +180,93 @@ describe("the profiles listing", () => {
   it("keeps the title and the body when the roster fails", async () => {
     profilesReadFails = true;
 
-    const html = await render(
-      <ProfilesListSection title="Artists">
-        <p>Roster notes</p>
-      </ProfilesListSection>,
-    );
+    const html = await renderRoster({
+      title: "Artists",
+      children: <p>Roster notes</p>,
+    });
 
     expect(html).toContain("Artists");
     expect(html).toContain("Roster notes");
     // And does not pass the failure off as a roster that is merely empty.
     expect(html).not.toContain("No artists found");
+  });
+});
+
+/**
+ * The roster pages like /archive and /shop: a shared `?page=`, hrefs against
+ * the page's own path, and the reader taken to the top of the new page.
+ *
+ * What it cannot borrow from them is their arithmetic. `count` is optional on
+ * the profiles response, so there is no total to divide into pages, and the
+ * only end-of-roster signal available is a page that came back short. That is
+ * the same rule the SDK applies to a `profileListing` block, which is what
+ * keeps the two surfaces agreeing about where the roster ends.
+ */
+describe("the profile roster's pager", () => {
+  it("asks the endpoint for the page it was given", async () => {
+    profileRecords = aRoster(PROFILES_PER_PAGE);
+
+    await renderRoster({ currentPage: 2 });
+
+    expect(new URL(requestedUrls()[0]).searchParams.get("page")).toBe("2");
+  });
+
+  it("links on to the next page while pages come back full", async () => {
+    profileRecords = aRoster(PROFILES_PER_PAGE);
+
+    expect(await renderRoster()).toContain("/p/roster?page=1");
+  });
+
+  // The short page is the end of the roster; offering a next link here walks
+  // the reader onto a page that is empty by construction.
+  it("offers no next page from a short one", async () => {
+    profileRecords = aRoster(PROFILES_PER_PAGE - 1);
+
+    expect(await renderRoster()).not.toContain("page=1");
+  });
+
+  it("offers no previous page from the first", async () => {
+    profileRecords = aRoster(PROFILES_PER_PAGE);
+
+    expect(await renderRoster()).not.toContain("Previous page");
+  });
+
+  // A roster whose length is an exact multiple of the page size hands out a
+  // next link to an empty page. Dropping the pager there would strand a reader
+  // who followed it with no way back.
+  it("keeps a way back off an empty page", async () => {
+    profileRecords = [];
+
+    expect(await renderRoster({ currentPage: 2 })).toContain(
+      "/p/roster?page=1",
+    );
+  });
+
+  // Paging the roster must not reset a listing block sitting in the page's
+  // own body, which pages by a param of its own.
+  it("carries the page's other params through", async () => {
+    profileRecords = aRoster(PROFILES_PER_PAGE);
+
+    const html = await renderRoster({
+      searchParams: { page: "0", prf_9k3z1: "3" },
+    });
+
+    expect(html).toContain("prf_9k3z1=3");
+  });
+
+  // A PROFILELIST page can carry several pagers — every listing block in its
+  // body brings one — so the roster's landmark needs a name of its own.
+  it("names its own nav", async () => {
+    profileRecords = aRoster(PROFILES_PER_PAGE);
+
+    expect(await renderRoster()).toContain('aria-label="Artists pagination"');
+  });
+
+  // Nothing to page is nothing to draw: a single-page roster gets no nav of
+  // two dead arrows.
+  it("draws no pager for a roster that fits on one page", async () => {
+    profileRecords = aRoster(3);
+
+    expect(await renderRoster()).not.toContain("Artists pagination");
   });
 });

--- a/src/components/ProfilesPage/ProfilesListContent.test.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.test.tsx
@@ -1,0 +1,132 @@
+import { setConfig } from "@venuecms/sdk-next";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProfilesListContent } from "./ProfilesListContent";
+import { ProfilesListSection } from "./ProfilesListSection";
+
+vi.mock("next/server", () => ({ connection: async () => {} }));
+
+// ColumnLeft is emitted first, so a body moved into it still reads as "before
+// the profiles" unless the assertion names the column that should hold it.
+const columnRight = (html: string) => html.split('class="col-span-2')[1] ?? "";
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(
+    <NextIntlClientProvider locale="en" messages={{}}>
+      {node}
+    </NextIntlClientProvider>,
+  );
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+const requestedUrls = () =>
+  vi
+    .mocked(globalThis.fetch)
+    .mock.calls.map(([input]) =>
+      input instanceof Request ? input.url : String(input),
+    );
+
+let profileRecords: Array<Record<string, unknown>> = [];
+
+beforeEach(() => {
+  setConfig({ siteKey: "test-site" });
+  profileRecords = [];
+
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = input instanceof Request ? input.url : String(input);
+
+    const body = url.includes("/profiles")
+      ? { records: profileRecords, count: profileRecords.length }
+      : { id: "site-id", timeZone: "Europe/Berlin", settings: {} };
+
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const aProfile = (title: string) => ({
+  siteId: "site-id",
+  slug: title.toLowerCase().replace(/\s+/g, "-"),
+  localizedContent: [{ siteId: "site-id", locale: "en", title }],
+});
+
+describe("the profiles listing", () => {
+  it("draws the profiles the endpoint returned", async () => {
+    profileRecords = [aProfile("An Artist")];
+
+    const html = await render(<ProfilesListContent title="Artists" />);
+
+    expect(html).toContain("An Artist");
+    expect(html).toContain("/artists/an-artist");
+  });
+
+  it("heads itself with the listing page's own title", async () => {
+    expect(await render(<ProfilesListContent title="Roster" />)).toContain(
+      "Roster",
+    );
+  });
+
+  // Unlike events and shop, this template has no /profiles route and so no page
+  // record to fall back to, which is why the heading is only ever the page's.
+  it("falls back to a heading of its own without one", async () => {
+    const html = await render(<ProfilesListContent />);
+
+    expect(html).toContain("artists");
+    expect(requestedUrls().some((url) => url.includes("/pages"))).toBe(false);
+  });
+
+  it("says so when there are no profiles", async () => {
+    expect(await render(<ProfilesListContent title="Artists" />)).toContain(
+      "No artists found",
+    );
+  });
+
+  // A profile card needs no site, so asking for one would only add a request
+  // that a failed read could then 404 the whole page on.
+  it("reads no site", async () => {
+    await render(<ProfilesListContent title="Artists" />);
+
+    expect(requestedUrls().every((url) => url.includes("/profiles"))).toBe(true);
+  });
+
+  it("renders a body it was handed above the profiles", async () => {
+    profileRecords = [aProfile("An Artist")];
+
+    const column = columnRight(
+      await render(
+        <ProfilesListContent title="Artists">
+          <p>Roster notes</p>
+        </ProfilesListContent>,
+      ),
+    );
+
+    expect(column.indexOf("Roster notes")).toBeGreaterThan(-1);
+    expect(column.indexOf("Roster notes")).toBeLessThan(
+      column.indexOf("An Artist"),
+    );
+  });
+});
+
+describe("the profiles listing section", () => {
+  it("hands the body it was given to the content it wraps", async () => {
+    const column = columnRight(
+      await render(
+        <ProfilesListSection title="Artists">
+          <p>Roster notes</p>
+        </ProfilesListSection>,
+      ),
+    );
+
+    expect(column).toContain("Roster notes");
+  });
+});

--- a/src/components/ProfilesPage/ProfilesListContent.test.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.test.tsx
@@ -52,11 +52,14 @@ const renderRoster = (
 
 let profileRecords: Array<Record<string, unknown>> = [];
 let profilesReadFails = false;
+/** The roster's total, or null for the endpoint answering without one. */
+let profilesCount: number | null = null;
 
 beforeEach(() => {
   setConfig({ siteKey: "test-site" });
   profileRecords = [];
   profilesReadFails = false;
+  profilesCount = null;
 
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = input instanceof Request ? input.url : String(input);
@@ -67,7 +70,9 @@ beforeEach(() => {
         : new Response(
             JSON.stringify({
               records: profileRecords,
-              count: profileRecords.length,
+              // Omitted, not nulled, when there is none: `count` is optional on
+              // this response and a real endpoint leaves the key off entirely.
+              ...(profilesCount === null ? {} : { count: profilesCount }),
             }),
             { status: 200, headers: { "content-type": "application/json" } },
           );
@@ -196,11 +201,9 @@ describe("the profiles listing", () => {
  * The roster pages like /archive and /shop: a shared `?page=`, hrefs against
  * the page's own path, and the reader taken to the top of the new page.
  *
- * What it cannot borrow from them is their arithmetic. `count` is optional on
- * the profiles response, so there is no total to divide into pages, and the
- * only end-of-roster signal available is a page that came back short. That is
- * the same rule the SDK applies to a `profileListing` block, which is what
- * keeps the two surfaces agreeing about where the roster ends.
+ * What it cannot borrow from them is a single piece of arithmetic. `count` is
+ * optional on the profiles response, so the end of the roster is found one of
+ * two ways depending on whether the endpoint volunteered a total.
  */
 describe("the profile roster's pager", () => {
   it("asks the endpoint for the page it was given", async () => {
@@ -211,29 +214,15 @@ describe("the profile roster's pager", () => {
     expect(new URL(requestedUrls()[0]).searchParams.get("page")).toBe("2");
   });
 
-  it("links on to the next page while pages come back full", async () => {
-    profileRecords = aRoster(PROFILES_PER_PAGE);
-
-    expect(await renderRoster()).toContain("/p/roster?page=1");
-  });
-
-  // The short page is the end of the roster; offering a next link here walks
-  // the reader onto a page that is empty by construction.
-  it("offers no next page from a short one", async () => {
-    profileRecords = aRoster(PROFILES_PER_PAGE - 1);
-
-    expect(await renderRoster()).not.toContain("page=1");
-  });
-
   it("offers no previous page from the first", async () => {
     profileRecords = aRoster(PROFILES_PER_PAGE);
+    profilesCount = PROFILES_PER_PAGE * 3;
 
     expect(await renderRoster()).not.toContain("Previous page");
   });
 
-  // A roster whose length is an exact multiple of the page size hands out a
-  // next link to an empty page. Dropping the pager there would strand a reader
-  // who followed it with no way back.
+  // A reader who overshoots the roster — by following the countless case's
+  // speculative next link, or by hand-editing the URL — must not be stranded.
   it("keeps a way back off an empty page", async () => {
     profileRecords = [];
 
@@ -266,7 +255,54 @@ describe("the profile roster's pager", () => {
   // two dead arrows.
   it("draws no pager for a roster that fits on one page", async () => {
     profileRecords = aRoster(3);
+    profilesCount = 3;
 
     expect(await renderRoster()).not.toContain("Artists pagination");
+  });
+
+  // Given a total, the records already behind the reader plus the ones on this
+  // page settle exactly where the roster ends.
+  describe("given a count", () => {
+    it("links on while records remain beyond this page", async () => {
+      profileRecords = aRoster(PROFILES_PER_PAGE);
+      profilesCount = PROFILES_PER_PAGE + 1;
+
+      expect(await renderRoster()).toContain("/p/roster?page=1");
+    });
+
+    // The bug a full page alone cannot see: 50 of 50 is the end of the roster,
+    // not the middle of it.
+    it("offers no next page from a full last one", async () => {
+      profileRecords = aRoster(PROFILES_PER_PAGE);
+      profilesCount = PROFILES_PER_PAGE;
+
+      expect(await renderRoster()).not.toContain("page=1");
+    });
+
+    it("offers no next page from the last of several", async () => {
+      profileRecords = aRoster(PROFILES_PER_PAGE);
+      profilesCount = PROFILES_PER_PAGE * 2;
+
+      expect(await renderRoster({ currentPage: 1 })).not.toContain("page=2");
+    });
+  });
+
+  // Without one, a page that came back full is the only evidence another may
+  // follow — the same rule the SDK pages a `profileListing` block by, which is
+  // what keeps the two surfaces agreeing about where the roster ends.
+  describe("given no count", () => {
+    it("links on while pages come back full", async () => {
+      profileRecords = aRoster(PROFILES_PER_PAGE);
+
+      expect(await renderRoster()).toContain("/p/roster?page=1");
+    });
+
+    // The short page is the end of the roster; a next link here walks the
+    // reader onto a page that is empty by construction.
+    it("offers no next page from a short one", async () => {
+      profileRecords = aRoster(PROFILES_PER_PAGE - 1);
+
+      expect(await renderRoster()).not.toContain("page=1");
+    });
   });
 });

--- a/src/components/ProfilesPage/ProfilesListContent.test.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.test.tsx
@@ -18,6 +18,9 @@ const render = async (node: ReactNode) => {
     <NextIntlClientProvider locale="en" messages={{}}>
       {node}
     </NextIntlClientProvider>,
+    // The roster's boundary is expected to catch a failed read; without this
+    // the recoverable error still reaches the console and reads as a test error.
+    { onError: () => {} },
   );
   await stream.allReady;
   return new Response(stream).text();
@@ -30,23 +33,43 @@ const requestedUrls = () =>
       input instanceof Request ? input.url : String(input),
     );
 
+const aProfile = (title: string) => ({
+  siteId: "site-id",
+  slug: title.toLowerCase().replace(/\s+/g, "-"),
+  localizedContent: [{ siteId: "site-id", locale: "en", title }],
+});
+
 let profileRecords: Array<Record<string, unknown>> = [];
+let profilesReadFails = false;
 
 beforeEach(() => {
   setConfig({ siteKey: "test-site" });
   profileRecords = [];
+  profilesReadFails = false;
 
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = input instanceof Request ? input.url : String(input);
 
-    const body = url.includes("/profiles")
-      ? { records: profileRecords, count: profileRecords.length }
-      : { id: "site-id", timeZone: "Europe/Berlin", settings: {} };
+    if (url.includes("/profiles")) {
+      return profilesReadFails
+        ? new Response("upstream is down", { status: 500 })
+        : new Response(
+            JSON.stringify({
+              records: profileRecords,
+              count: profileRecords.length,
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+    }
 
-    return new Response(JSON.stringify(body), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({
+        id: "site-id",
+        timeZone: "Europe/Berlin",
+        settings: {},
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
   });
 });
 
@@ -54,71 +77,81 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-const aProfile = (title: string) => ({
-  siteId: "site-id",
-  slug: title.toLowerCase().replace(/\s+/g, "-"),
-  localizedContent: [{ siteId: "site-id", locale: "en", title }],
-});
-
 describe("the profiles listing", () => {
   it("draws the profiles the endpoint returned", async () => {
     profileRecords = [aProfile("An Artist")];
 
-    const html = await render(<ProfilesListContent title="Artists" />);
+    const html = await render(<ProfilesListSection title="Artists" />);
 
     expect(html).toContain("An Artist");
     expect(html).toContain("/artists/an-artist");
   });
 
   it("heads itself with the listing page's own title", async () => {
-    expect(await render(<ProfilesListContent title="Roster" />)).toContain(
+    expect(await render(<ProfilesListSection title="Roster" />)).toContain(
       "Roster",
     );
   });
 
   // Unlike events and shop, this template has no /profiles route and so no page
   // record to fall back to, which is why the heading is only ever the page's.
-  it("falls back to a heading of its own without one", async () => {
-    const html = await render(<ProfilesListContent />);
+  // A locale saved without a title yields "", not undefined, so the fallback
+  // has to read emptiness rather than absence or the heading column draws blank.
+  it.each([
+    ["no title", undefined],
+    ["an empty title", ""],
+    ["a whitespace-only title", "   "],
+  ])("falls back to a heading of its own given %s", async (_label, title) => {
+    const html = await render(<ProfilesListSection title={title} />);
 
     expect(html).toContain("artists");
     expect(requestedUrls().some((url) => url.includes("/pages"))).toBe(false);
   });
 
   it("says so when there are no profiles", async () => {
-    expect(await render(<ProfilesListContent title="Artists" />)).toContain(
+    expect(await render(<ProfilesListSection title="Artists" />)).toContain(
       "No artists found",
+    );
+  });
+
+  // An outage rendered as an empty roster is a cached 200 claiming the site has
+  // no artists, which is why the read has to fail loudly rather than fall
+  // through to the empty state. Asserted on the throw rather than on rendered
+  // markup: the boundary that catches it is a client component, and React hands
+  // a suspended boundary's error to the client rather than running it in SSR.
+  it("fails loudly rather than reporting an outage as an empty roster", async () => {
+    profilesReadFails = true;
+
+    await expect(ProfilesListContent()).rejects.toThrow(
+      "The profiles endpoint could not be read.",
     );
   });
 
   // A profile card needs no site, so asking for one would only add a request
   // that a failed read could then 404 the whole page on.
   it("reads no site", async () => {
-    await render(<ProfilesListContent title="Artists" />);
+    await render(<ProfilesListSection title="Artists" />);
 
-    expect(requestedUrls().every((url) => url.includes("/profiles"))).toBe(true);
+    expect(requestedUrls().every((url) => url.includes("/profiles"))).toBe(
+      true,
+    );
+  });
+
+  // A `profileListing` block sends no ordering unless its author picks one.
+  // Sending one here would order the same roster differently on the two
+  // surfaces the shared `ProfilesList` exists to keep identical.
+  it("orders the roster the way a content block does", async () => {
+    await render(<ProfilesListSection title="Artists" />);
+
+    const query = new URL(requestedUrls()[0]).searchParams;
+
+    expect(query.get("dir")).toBeNull();
+    expect(query.get("orderBy")).toBeNull();
   });
 
   it("renders a body it was handed above the profiles", async () => {
     profileRecords = [aProfile("An Artist")];
 
-    const column = columnRight(
-      await render(
-        <ProfilesListContent title="Artists">
-          <p>Roster notes</p>
-        </ProfilesListContent>,
-      ),
-    );
-
-    expect(column.indexOf("Roster notes")).toBeGreaterThan(-1);
-    expect(column.indexOf("Roster notes")).toBeLessThan(
-      column.indexOf("An Artist"),
-    );
-  });
-});
-
-describe("the profiles listing section", () => {
-  it("hands the body it was given to the content it wraps", async () => {
     const column = columnRight(
       await render(
         <ProfilesListSection title="Artists">
@@ -127,6 +160,27 @@ describe("the profiles listing section", () => {
       ),
     );
 
-    expect(column).toContain("Roster notes");
+    expect(column.indexOf("Roster notes")).toBeGreaterThan(-1);
+    expect(column.indexOf("Roster notes")).toBeLessThan(
+      column.indexOf("An Artist"),
+    );
+  });
+
+  // The heading and the body cost no request of their own, so they sit outside
+  // the boundaries: a roster failure has no business taking an author's prose
+  // or the page's title down with it.
+  it("keeps the title and the body when the roster fails", async () => {
+    profilesReadFails = true;
+
+    const html = await render(
+      <ProfilesListSection title="Artists">
+        <p>Roster notes</p>
+      </ProfilesListSection>,
+    );
+
+    expect(html).toContain("Artists");
+    expect(html).toContain("Roster notes");
+    // And does not pass the failure off as a roster that is merely empty.
+    expect(html).not.toContain("No artists found");
   });
 });

--- a/src/components/ProfilesPage/ProfilesListContent.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.tsx
@@ -1,49 +1,39 @@
 import { getProfiles } from "@venuecms/sdk-next";
 import { connection } from "next/server";
-import type { ReactNode } from "react";
 
 import { ProfilesList } from "@/components/ProfileList";
-import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
 
-// One page of profiles, matching the roster template-liminal lists. The
-// endpoint pages, but no route here does: profiles are a cast list, not a feed,
-// and `count` is optional on that response, so a pager could not size itself.
+// One page of profiles, matching the roster template-liminal lists and the cap
+// /events already puts on its own index. Records past it are not reachable from
+// this page; giving it a pager is a follow-up, not a silent detail.
 const PROFILE_LIMIT = 99;
 
-export async function ProfilesListContent({
-  title,
-  children,
-}: {
-  /**
-   * Heading. Always the listing page's own: unlike events and shop, this
-   * template has no /profiles route and so no page record to read one from.
-   */
-  title?: string;
-  children?: ReactNode;
-}) {
+/**
+ * The records half of the profile listing. Draws only the grid: its frame, its
+ * heading and the page's own body live in `ProfilesListSection`, above the
+ * Suspense boundary, so none of them wait on this fetch or vanish with it.
+ */
+export async function ProfilesListContent() {
   await connection();
 
-  const { data: profiles } = await getProfiles({
-    limit: PROFILE_LIMIT,
-    dir: "desc",
-  });
+  // No `dir`/`orderBy`: a `profileListing` block sends neither unless its author
+  // picks one, so leaving them off is what makes this page and that block order
+  // the same roster the same way.
+  const { data: profiles } = await getProfiles({ limit: PROFILE_LIMIT });
+
+  // The SDK reports a failed read as absent data rather than throwing, which
+  // would otherwise render an outage as an empty roster — a cached 200 saying
+  // the site has no artists. Throwing hands it to the error boundary instead.
+  if (!profiles) {
+    throw new Error("The profiles endpoint could not be read.");
+  }
 
   // No site read, and so no `notFound` on a failed one: a profile card draws
   // from the profile alone, and asking would only add a request that could
   // take the page down with it.
-  return (
-    <TwoColumnLayout>
-      <ColumnLeft className="text-sm text-secondary">
-        <p className="pb-8 text-primary">{title ?? "artists"}</p>
-      </ColumnLeft>
-      <ColumnRight>
-        {children}
-        {profiles?.records.length ? (
-          <ProfilesList profiles={profiles.records} />
-        ) : (
-          "No artists found"
-        )}
-      </ColumnRight>
-    </TwoColumnLayout>
+  return profiles.records.length ? (
+    <ProfilesList profiles={profiles.records} />
+  ) : (
+    "No artists found"
   );
 }

--- a/src/components/ProfilesPage/ProfilesListContent.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.tsx
@@ -40,23 +40,32 @@ export async function ProfilesListContent({
     throw new Error("The profiles endpoint could not be read.");
   }
 
-  const { records } = profiles;
+  const { records, count } = profiles;
 
-  // `count` is optional on the profiles response, so unlike /shop there is no
-  // total to divide into pages: a page that came back full is the only evidence
-  // another may follow. The SDK pages a `profileListing` block by that same
-  // rule, which is what keeps the two surfaces agreeing where the roster ends.
+  // `count` is optional on the profiles response, so the roster's end is found
+  // two ways. Given a count, the records already behind the reader plus the
+  // ones on this page settle it exactly. Without one, a page that came back
+  // full is the only evidence another may follow — the rule the SDK pages a
+  // `profileListing` block by, which is what keeps the two surfaces agreeing
+  // about where the roster ends.
   //
-  // It does mean a roster whose length is an exact multiple of the page size
-  // offers one link to an empty page. That page keeps its pager rather than
-  // stranding whoever followed it.
+  // The countless case does mean a roster whose length is an exact multiple of
+  // the page size offers one link to an empty page. That page keeps its pager
+  // rather than stranding whoever followed it.
+  const hasNextPage =
+    typeof count === "number"
+      ? (currentPage + 1) * PROFILES_PER_PAGE < count
+      : records.length === PROFILES_PER_PAGE;
+
   const prevHref =
     currentPage > 0
       ? buildPageHref(basePath, searchParams, currentPage - 1)
       : null;
 
+  // Clamped at the deepest offset the endpoint will scan, so a pager cannot
+  // walk a reader past the page the SDK would refuse anyway.
   const nextHref =
-    records.length === PROFILES_PER_PAGE && currentPage < MAX_PAGE
+    hasNextPage && currentPage < MAX_PAGE
       ? buildPageHref(basePath, searchParams, currentPage + 1)
       : null;
 

--- a/src/components/ProfilesPage/ProfilesListContent.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.tsx
@@ -1,25 +1,37 @@
-import { getProfiles } from "@venuecms/sdk-next";
+import { MAX_PAGE, type SearchParams, getProfiles } from "@venuecms/sdk-next";
 import { connection } from "next/server";
 
+import { PaginationLinks } from "@/components/Pagination";
 import { ProfilesList } from "@/components/ProfileList";
+import { buildPageHref } from "@/components/utils/searchParams";
 
-// One page of profiles, matching the roster template-liminal lists and the cap
-// /events already puts on its own index. Records past it are not reachable from
-// this page; giving it a pager is a follow-up, not a silent detail.
-const PROFILE_LIMIT = 99;
+/** The page size /archive and /shop use, this template's other paged indexes. */
+export const PROFILES_PER_PAGE = 50;
 
 /**
- * The records half of the profile listing. Draws only the grid: its frame, its
+ * The records half of the profile listing, and its pager. The frame, the
  * heading and the page's own body live in `ProfilesListSection`, above the
  * Suspense boundary, so none of them wait on this fetch or vanish with it.
  */
-export async function ProfilesListContent() {
+export async function ProfilesListContent({
+  currentPage,
+  basePath,
+  searchParams = {},
+}: {
+  currentPage: number;
+  /** Path the pager builds hrefs against; only the route knows it. */
+  basePath: string;
+  searchParams?: SearchParams;
+}) {
   await connection();
 
   // No `dir`/`orderBy`: a `profileListing` block sends neither unless its author
   // picks one, so leaving them off is what makes this page and that block order
   // the same roster the same way.
-  const { data: profiles } = await getProfiles({ limit: PROFILE_LIMIT });
+  const { data: profiles } = await getProfiles({
+    page: currentPage,
+    limit: PROFILES_PER_PAGE,
+  });
 
   // The SDK reports a failed read as absent data rather than throwing, which
   // would otherwise render an outage as an empty roster — a cached 200 saying
@@ -28,12 +40,45 @@ export async function ProfilesListContent() {
     throw new Error("The profiles endpoint could not be read.");
   }
 
+  const { records } = profiles;
+
+  // `count` is optional on the profiles response, so unlike /shop there is no
+  // total to divide into pages: a page that came back full is the only evidence
+  // another may follow. The SDK pages a `profileListing` block by that same
+  // rule, which is what keeps the two surfaces agreeing where the roster ends.
+  //
+  // It does mean a roster whose length is an exact multiple of the page size
+  // offers one link to an empty page. That page keeps its pager rather than
+  // stranding whoever followed it.
+  const prevHref =
+    currentPage > 0
+      ? buildPageHref(basePath, searchParams, currentPage - 1)
+      : null;
+
+  const nextHref =
+    records.length === PROFILES_PER_PAGE && currentPage < MAX_PAGE
+      ? buildPageHref(basePath, searchParams, currentPage + 1)
+      : null;
+
   // No site read, and so no `notFound` on a failed one: a profile card draws
   // from the profile alone, and asking would only add a request that could
   // take the page down with it.
-  return profiles.records.length ? (
-    <ProfilesList profiles={profiles.records} />
-  ) : (
-    "No artists found"
+  return (
+    <>
+      {records.length ? (
+        <ProfilesList profiles={records} />
+      ) : (
+        "No artists found"
+      )}
+      {prevHref || nextHref ? (
+        <PaginationLinks
+          prevHref={prevHref}
+          nextHref={nextHref}
+          // A PROFILELIST page can carry several pagers — every listing block
+          // in its body brings one — so this landmark needs a name of its own.
+          label="Artists pagination"
+        />
+      ) : null}
+    </>
   );
 }

--- a/src/components/ProfilesPage/ProfilesListContent.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.tsx
@@ -1,0 +1,49 @@
+import { getProfiles } from "@venuecms/sdk-next";
+import { connection } from "next/server";
+import type { ReactNode } from "react";
+
+import { ProfilesList } from "@/components/ProfileList";
+import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
+
+// One page of profiles, matching the roster template-liminal lists. The
+// endpoint pages, but no route here does: profiles are a cast list, not a feed,
+// and `count` is optional on that response, so a pager could not size itself.
+const PROFILE_LIMIT = 99;
+
+export async function ProfilesListContent({
+  title,
+  children,
+}: {
+  /**
+   * Heading. Always the listing page's own: unlike events and shop, this
+   * template has no /profiles route and so no page record to read one from.
+   */
+  title?: string;
+  children?: ReactNode;
+}) {
+  await connection();
+
+  const { data: profiles } = await getProfiles({
+    limit: PROFILE_LIMIT,
+    dir: "desc",
+  });
+
+  // No site read, and so no `notFound` on a failed one: a profile card draws
+  // from the profile alone, and asking would only add a request that could
+  // take the page down with it.
+  return (
+    <TwoColumnLayout>
+      <ColumnLeft className="text-sm text-secondary">
+        <p className="pb-8 text-primary">{title ?? "artists"}</p>
+      </ColumnLeft>
+      <ColumnRight>
+        {children}
+        {profiles?.records.length ? (
+          <ProfilesList profiles={profiles.records} />
+        ) : (
+          "No artists found"
+        )}
+      </ColumnRight>
+    </TwoColumnLayout>
+  );
+}

--- a/src/components/ProfilesPage/ProfilesListSection.tsx
+++ b/src/components/ProfilesPage/ProfilesListSection.tsx
@@ -1,3 +1,4 @@
+import type { SearchParams } from "@venuecms/sdk-next";
 import { Suspense } from "react";
 import type { ReactNode } from "react";
 
@@ -51,6 +52,9 @@ function ProfilesListSkeleton() {
  */
 export function ProfilesListSection({
   title,
+  currentPage,
+  basePath,
+  searchParams,
   children,
 }: {
   /**
@@ -58,6 +62,10 @@ export function ProfilesListSection({
    * template has no /profiles route and so no page record to read one from.
    */
   title?: string;
+  currentPage: number;
+  /** Path the pager builds hrefs against; only the route knows it. */
+  basePath: string;
+  searchParams?: SearchParams;
   /** The page's own body, rendered above the records. */
   children?: ReactNode;
 }) {
@@ -75,7 +83,11 @@ export function ProfilesListSection({
         {children}
         <ErrorBoundary fallback={<ProfilesListError />}>
           <Suspense fallback={<ProfilesListSkeleton />}>
-            <ProfilesListContent />
+            <ProfilesListContent
+              currentPage={currentPage}
+              basePath={basePath}
+              searchParams={searchParams}
+            />
           </Suspense>
         </ErrorBoundary>
       </ColumnRight>

--- a/src/components/ProfilesPage/ProfilesListSection.tsx
+++ b/src/components/ProfilesPage/ProfilesListSection.tsx
@@ -1,0 +1,68 @@
+import { Suspense } from "react";
+import type { ReactNode } from "react";
+
+import {
+  ColumnLeft,
+  ColumnRight,
+  TwoColumnLayout,
+  TwoSubColumnLayout,
+} from "@/components/layout";
+import { Skeleton } from "@/components/ui/Input/Skeleton";
+import { ErrorBoundary } from "@/components/utils/ErrorBoundary";
+
+import { ProfilesListContent } from "./ProfilesListContent";
+
+function ProfilesListError() {
+  return (
+    <TwoColumnLayout>
+      <ColumnLeft className="text-sm text-secondary" />
+      <ColumnRight>
+        <p className="text-secondary">
+          Unable to load artists. Please try refreshing the page.
+        </p>
+      </ColumnRight>
+    </TwoColumnLayout>
+  );
+}
+
+function ProfilesListSkeleton() {
+  return (
+    <TwoColumnLayout>
+      <ColumnLeft className="text-sm text-secondary">
+        <div className="pb-8">
+          <Skeleton className="w-32" />
+        </div>
+      </ColumnLeft>
+      <ColumnRight>
+        <TwoSubColumnLayout>
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="flex flex-col gap-6">
+              <Skeleton className="aspect-video w-full" />
+              <Skeleton className="w-32" />
+              <div className="flex flex-col gap-1">
+                <Skeleton className="w-full" />
+                <Skeleton className="w-3/4" />
+              </div>
+            </div>
+          ))}
+        </TwoSubColumnLayout>
+      </ColumnRight>
+    </TwoColumnLayout>
+  );
+}
+
+export function ProfilesListSection({
+  title,
+  children,
+}: {
+  title?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <ErrorBoundary fallback={<ProfilesListError />}>
+      <Suspense fallback={<ProfilesListSkeleton />}>
+        <ProfilesListContent title={title}>{children}</ProfilesListContent>
+      </Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/src/components/ProfilesPage/ProfilesListSection.tsx
+++ b/src/components/ProfilesPage/ProfilesListSection.tsx
@@ -14,55 +14,71 @@ import { ProfilesListContent } from "./ProfilesListContent";
 
 function ProfilesListError() {
   return (
-    <TwoColumnLayout>
-      <ColumnLeft className="text-sm text-secondary" />
-      <ColumnRight>
-        <p className="text-secondary">
-          Unable to load artists. Please try refreshing the page.
-        </p>
-      </ColumnRight>
-    </TwoColumnLayout>
+    <p className="text-secondary">
+      Unable to load artists. Please try refreshing the page.
+    </p>
   );
 }
 
 function ProfilesListSkeleton() {
   return (
-    <TwoColumnLayout>
-      <ColumnLeft className="text-sm text-secondary">
-        <div className="pb-8">
+    <TwoSubColumnLayout>
+      {[1, 2, 3, 4].map((i) => (
+        <div key={i} className="flex flex-col gap-6">
+          {/* `h-auto` so tailwind-merge drops Skeleton's own `h-4`, which would
+              otherwise win over the aspect ratio and collapse the card to a bar. */}
+          <Skeleton className="aspect-video h-auto w-full" />
           <Skeleton className="w-32" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="w-full" />
+            <Skeleton className="w-3/4" />
+          </div>
         </div>
-      </ColumnLeft>
-      <ColumnRight>
-        <TwoSubColumnLayout>
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="flex flex-col gap-6">
-              <Skeleton className="aspect-video w-full" />
-              <Skeleton className="w-32" />
-              <div className="flex flex-col gap-1">
-                <Skeleton className="w-full" />
-                <Skeleton className="w-3/4" />
-              </div>
-            </div>
-          ))}
-        </TwoSubColumnLayout>
-      </ColumnRight>
-    </TwoColumnLayout>
+      ))}
+    </TwoSubColumnLayout>
   );
 }
 
+/**
+ * The frame of the profile listing: the /events and /archive two-column index,
+ * since this template has no /profiles route of its own to mirror.
+ *
+ * The heading and the page's own body sit *outside* the boundaries on purpose.
+ * Both are already in hand — neither costs a request — so putting them under
+ * the Suspense would hide readable content behind the roster's skeleton and
+ * shift the layout when it resolved, and putting them under the ErrorBoundary
+ * would delete an author's prose because an unrelated fetch failed.
+ */
 export function ProfilesListSection({
   title,
   children,
 }: {
+  /**
+   * Heading. Always the listing page's own: unlike events and shop, this
+   * template has no /profiles route and so no page record to read one from.
+   */
   title?: string;
+  /** The page's own body, rendered above the records. */
   children?: ReactNode;
 }) {
+  // Emptiness, not absence: the route reads the title off the page's localized
+  // content, which is blank rather than missing for a locale saved without one,
+  // and `??` would keep that and draw an empty heading column.
+  const heading = title?.trim() ? title : "artists";
+
   return (
-    <ErrorBoundary fallback={<ProfilesListError />}>
-      <Suspense fallback={<ProfilesListSkeleton />}>
-        <ProfilesListContent title={title}>{children}</ProfilesListContent>
-      </Suspense>
-    </ErrorBoundary>
+    <TwoColumnLayout>
+      <ColumnLeft className="text-sm text-secondary">
+        <p className="pb-8 text-primary">{heading}</p>
+      </ColumnLeft>
+      <ColumnRight>
+        {children}
+        <ErrorBoundary fallback={<ProfilesListError />}>
+          <Suspense fallback={<ProfilesListSkeleton />}>
+            <ProfilesListContent />
+          </Suspense>
+        </ErrorBoundary>
+      </ColumnRight>
+    </TwoColumnLayout>
   );
 }

--- a/src/components/ProfilesPage/index.ts
+++ b/src/components/ProfilesPage/index.ts
@@ -1,0 +1,1 @@
+export { ProfilesListSection } from "./ProfilesListSection";

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -145,6 +145,9 @@ describe("the products listing body", () => {
   // Asserted on what survives rather than on the error copy: the boundary that
   // catches the bailout is a client component, and React hands a suspended
   // boundary's error to the client rather than running its fallback in SSR.
+  // That is also why this cannot see the boundary's *placement* — the body
+  // renders in the server output either way — so the placement itself is
+  // pinned in PageListing/boundaries.test.tsx, where the boundary is stubbed.
   it("keeps the body when the grid fails", async () => {
     siteReadFails = true;
 
@@ -155,8 +158,6 @@ describe("the products listing body", () => {
     );
 
     expect(html).toContain("Season notes");
-    // And does not pass the failure off as a shop that is merely empty.
-    expect(html).not.toContain("No products found");
   });
 });
 

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -4,7 +4,6 @@ import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ProductsListContent } from "./ProductsListContent";
 import { ProductsListSection } from "./ProductsListSection";
 
 vi.mock("next/server", () => ({ connection: async () => {} }));
@@ -27,43 +26,55 @@ const render = async (node: ReactNode) => {
     <NextIntlClientProvider locale="en" messages={{}}>
       {node}
     </NextIntlClientProvider>,
+    // The grid's boundary is expected to catch a failed read; without this the
+    // recoverable error still reaches the console and reads as a test error.
+    { onError: () => {} },
   );
   await stream.allReady;
   return new Response(stream).text();
 };
 
+const requestedUrls = () =>
+  vi
+    .mocked(globalThis.fetch)
+    .mock.calls.map(([input]) =>
+      input instanceof Request ? input.url : String(input),
+    );
+
+let siteReadFails = false;
+
 beforeEach(() => {
   setConfig({ siteKey: "test-site" });
+  siteReadFails = false;
 
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = input instanceof Request ? input.url : String(input);
 
-    let body: unknown = {
-      id: "site-id",
-      timeZone: "Europe/Berlin",
-      settings: {},
-    };
-
     if (url.includes("/products")) {
-      body = {
-        records: Array.from({ length: PAGE_SIZE }, (_, i) => ({
-          slug: `p${i}`,
-          localizedContent: [],
-        })),
-        count: COUNT,
-      };
-    } else if (url.includes("/pages")) {
-      body = {
-        id: "page-id",
-        slug: "shop",
-        localizedContent: [{ siteId: "site-id", locale: "en", title: "Shop" }],
-      };
+      return new Response(
+        JSON.stringify({
+          records: Array.from({ length: PAGE_SIZE }, (_, i) => ({
+            slug: `p${i}`,
+            localizedContent: [],
+          })),
+          count: COUNT,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
     }
 
-    return new Response(JSON.stringify(body), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
+    if (siteReadFails) {
+      return new Response("upstream is down", { status: 500 });
+    }
+
+    return new Response(
+      JSON.stringify({
+        id: "site-id",
+        timeZone: "Europe/Berlin",
+        settings: {},
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
   });
 });
 
@@ -74,7 +85,7 @@ afterEach(() => {
 describe("the products listing pager", () => {
   it("pages against the /shop route when that is what rendered it", async () => {
     const html = await render(
-      <ProductsListContent locale="en" currentPage={0} basePath="/shop" />,
+      <ProductsListSection currentPage={0} basePath="/shop" />,
     );
 
     expect(html).toContain("/shop?page=1");
@@ -82,7 +93,7 @@ describe("the products listing pager", () => {
 
   it("pages against the page it is rendered on, not /shop", async () => {
     const html = await render(
-      <ProductsListContent locale="en" currentPage={1} basePath="/p/merch" />,
+      <ProductsListSection currentPage={1} basePath="/p/merch" />,
     );
 
     expect(html).toContain("/p/merch?page=0");
@@ -93,8 +104,7 @@ describe("the products listing pager", () => {
   // Without this the body's listing block snaps back to its first page.
   it("keeps a listing block's own param when paging the route", async () => {
     const html = await render(
-      <ProductsListContent
-        locale="en"
+      <ProductsListSection
         currentPage={1}
         basePath="/p/merch"
         searchParams={{ page: "1", evt_9k3z1: "3" }}
@@ -109,9 +119,9 @@ describe("the products listing body", () => {
   it("renders a body it was handed above the products", async () => {
     const section = listingSection(
       await render(
-        <ProductsListContent locale="en" currentPage={0} basePath="/p/merch">
+        <ProductsListSection currentPage={0} basePath="/p/merch">
           <p>Season notes</p>
-        </ProductsListContent>,
+        </ProductsListSection>,
       ),
     );
 
@@ -123,23 +133,37 @@ describe("the products listing body", () => {
 
   it("renders no body wrapper for the /shop route, which passes none", async () => {
     const html = await render(
-      <ProductsListContent locale="en" currentPage={0} basePath="/shop" />,
+      <ProductsListSection currentPage={0} basePath="/shop" />,
     );
 
     expect(html).not.toContain('class="pb-20"');
   });
-});
 
-describe("the products listing section", () => {
-  it("hands the body it was given to the content it wraps", async () => {
-    const section = listingSection(
-      await render(
-        <ProductsListSection locale="en" currentPage={0} basePath="/p/merch">
-          <p>Season notes</p>
-        </ProductsListSection>,
-      ),
+  // The body costs no request of its own, so it sits outside the boundaries: a
+  // failed grid read has no business taking an author's prose down with it.
+  //
+  // Asserted on what survives rather than on the error copy: the boundary that
+  // catches the bailout is a client component, and React hands a suspended
+  // boundary's error to the client rather than running its fallback in SSR.
+  it("keeps the body when the grid fails", async () => {
+    siteReadFails = true;
+
+    const html = await render(
+      <ProductsListSection currentPage={0} basePath="/p/merch">
+        <p>Season notes</p>
+      </ProductsListSection>,
     );
 
-    expect(section).toContain("Season notes");
+    expect(html).toContain("Season notes");
+    // And does not pass the failure off as a shop that is merely empty.
+    expect(html).not.toContain("No products found");
   });
+});
+
+// The grid has no heading slot, so the record that would only have supplied a
+// title is not worth a round trip on every render.
+it("reads no page record for a title it has nowhere to draw", async () => {
+  await render(<ProductsListSection currentPage={0} basePath="/shop" />);
+
+  expect(requestedUrls().some((url) => url.includes("/pages"))).toBe(false);
 });

--- a/src/components/ShopPage/ProductsListContent.tsx
+++ b/src/components/ShopPage/ProductsListContent.tsx
@@ -1,6 +1,5 @@
 import type { SearchParams } from "@venuecms/sdk-next";
-import { getLocalizedContent } from "@venuecms/sdk-next";
-import { getPage, getProducts, getSite } from "@venuecms/sdk-next";
+import { getProducts, getSite } from "@venuecms/sdk-next";
 import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
@@ -9,31 +8,32 @@ import { Pagination } from "@/components/Pagination";
 
 const ITEMS_PER_PAGE = 50;
 
+/**
+ * The records half of the products listing, and its pager. The frame and any
+ * page body live in `ProductsListSection`, above the Suspense boundary, so
+ * neither waits on this fetch or vanishes with it.
+ *
+ * No page record is read: this grid has no heading slot to put a title in.
+ */
 export async function ProductsListContent({
-  locale,
   currentPage,
   basePath,
   searchParams,
-  children,
 }: {
-  locale: string;
   currentPage: number;
   /** Path the pager builds hrefs against; a listing page pages against its own /p/<slug>. */
   basePath: string;
   searchParams?: SearchParams;
-  children?: React.ReactNode;
 }) {
   await connection();
 
-  const [{ data: products }, { data: page }, { data: site }] =
-    await Promise.all([
-      getProducts({
-        page: currentPage,
-        limit: ITEMS_PER_PAGE,
-      }),
-      getPage({ slug: "shop" }),
-      getSite(),
-    ]);
+  const [{ data: products }, { data: site }] = await Promise.all([
+    getProducts({
+      page: currentPage,
+      limit: ITEMS_PER_PAGE,
+    }),
+    getSite(),
+  ]);
 
   if (!site) {
     notFound();
@@ -44,16 +44,11 @@ export async function ProductsListContent({
     ? Math.ceil(products.count / ITEMS_PER_PAGE)
     : 100;
 
-  const pageTitle = page
-    ? getLocalizedContent(page.localizedContent, locale).content.title
-    : "Shop";
-
   const topProducts = products?.records.slice(0, 4);
   const moreProducts = products?.records.slice(4);
 
   return (
-    <section className="py-20">
-      {children ? <div className="pb-20">{children}</div> : null}
+    <>
       <div className="grid gap-8 pb-20 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
         {topProducts?.length
           ? topProducts.map((product) => (
@@ -81,6 +76,6 @@ export async function ProductsListContent({
           searchParams={searchParams}
         />
       ) : null}
-    </section>
+    </>
   );
 }

--- a/src/components/ShopPage/ProductsListSection.tsx
+++ b/src/components/ShopPage/ProductsListSection.tsx
@@ -8,57 +8,60 @@ import { ProductsListContent } from "./ProductsListContent";
 
 function ProductsListError() {
   return (
-    <section className="py-20">
-      <p className="text-secondary">
-        Unable to load products. Please try refreshing the page.
-      </p>
-    </section>
+    <p className="text-secondary">
+      Unable to load products. Please try refreshing the page.
+    </p>
   );
 }
 
 function ProductsListSkeleton() {
   return (
-    <section className="py-20">
-      <div className="grid gap-8 pb-20 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
-        {[1, 2, 3, 4].map((i) => (
-          <div key={i} className="flex flex-col gap-3">
-            <Skeleton className="aspect-square" />
-            <div className="flex flex-col gap-1">
-              <Skeleton className="h-3 w-1/2" />
-              <Skeleton className="w-3/4" />
-            </div>
+    <div className="grid gap-8 pb-20 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
+      {[1, 2, 3, 4].map((i) => (
+        <div key={i} className="flex flex-col gap-3">
+          <Skeleton className="aspect-square" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-3 w-1/2" />
+            <Skeleton className="w-3/4" />
           </div>
-        ))}
-      </div>
-    </section>
+        </div>
+      ))}
+    </div>
   );
 }
 
+/**
+ * The frame of the products listing, shared by /shop and by a PRODUCTLIST page.
+ *
+ * The page's own body sits *outside* the boundaries on purpose. It is already
+ * in hand and costs no request, so putting it under the Suspense would hide
+ * readable content behind the grid's skeleton and shift the layout when it
+ * resolved, and putting it under the ErrorBoundary would delete an author's
+ * prose because an unrelated fetch failed.
+ */
 export function ProductsListSection({
-  locale,
   currentPage,
   basePath,
   searchParams,
   children,
 }: {
-  locale: string;
   currentPage: number;
   basePath: string;
   searchParams?: SearchParams;
   children?: React.ReactNode;
 }) {
   return (
-    <ErrorBoundary fallback={<ProductsListError />}>
-      <Suspense fallback={<ProductsListSkeleton />}>
-        <ProductsListContent
-          locale={locale}
-          currentPage={currentPage}
-          basePath={basePath}
-          searchParams={searchParams}
-        >
-          {children}
-        </ProductsListContent>
-      </Suspense>
-    </ErrorBoundary>
+    <section className="py-20">
+      {children ? <div className="pb-20">{children}</div> : null}
+      <ErrorBoundary fallback={<ProductsListError />}>
+        <Suspense fallback={<ProductsListSkeleton />}>
+          <ProductsListContent
+            currentPage={currentPage}
+            basePath={basePath}
+            searchParams={searchParams}
+          />
+        </Suspense>
+      </ErrorBoundary>
+    </section>
   );
 }

--- a/src/components/utils/pageContent.test.ts
+++ b/src/components/utils/pageContent.test.ts
@@ -51,6 +51,33 @@ describe("hasRenderableContent", () => {
     expect(hasRenderableContent(localized({ contentJSON }))).toBe(false);
   });
 
+  /**
+   * The fields disagree, and the renderer's answer is the one that counts:
+   * `VenueContent` draws `contentJSON` whenever it is present and only reads
+   * the markdown when it is not. A record whose editor doc was cleared while a
+   * stale markdown mirror stayed behind therefore renders nothing, so judging
+   * the markdown first would space the listing around an empty body.
+   */
+  it("is false for an emptied doc still carrying stale markdown", () => {
+    expect(
+      hasRenderableContent(
+        localized({
+          content: "## Notes from a previous edit",
+          contentJSON: { type: "doc", content: [{ type: "paragraph" }] },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  // And the mirror is still what a body with no doc at all is judged by.
+  it("is true for markdown with no doc beside it", () => {
+    expect(
+      hasRenderableContent(
+        localized({ content: "## Notes", contentJSON: null }),
+      ),
+    ).toBe(true);
+  });
+
   // A node the reader can see, even with no text of its own, is content.
   it("is true for a doc holding only an image", () => {
     expect(

--- a/src/components/utils/pageContent.ts
+++ b/src/components/utils/pageContent.ts
@@ -7,13 +7,20 @@ import type { LocalizedContent } from "@venuecms/sdk-next";
  * one empty paragraph, so a caller guarding on the field alone spaces around
  * nothing. Only a paragraph is judged by its children: an image or an embed
  * carries no text and is still content.
+ *
+ * The two fields are judged in the renderer's own order rather than the other
+ * way round. `VenueContent` draws `contentJSON` whenever it is present and only
+ * falls back to the `content` markdown when it is not, so a record still
+ * carrying a stale markdown mirror under an emptied editor doc renders nothing.
+ * Reading the markdown first would call that body renderable on the strength of
+ * a field the renderer is never going to reach.
  */
 export const hasRenderableContent = (content?: LocalizedContent): boolean => {
-  if (content?.content?.trim()) {
-    return true;
+  if (!content?.contentJSON) {
+    return Boolean(content?.content?.trim());
   }
 
-  const nodes = content?.contentJSON?.content;
+  const nodes = content.contentJSON.content;
 
   if (!Array.isArray(nodes)) {
     return false;

--- a/src/components/utils/pageLayout.test.ts
+++ b/src/components/utils/pageLayout.test.ts
@@ -8,15 +8,12 @@ describe("resolvePageListingLayout", () => {
     expect(resolvePageListingLayout("NEWSLIST")).toBe("news");
     expect(resolvePageListingLayout("EVENTLIST")).toBe("events");
     expect(resolvePageListingLayout("PRODUCTLIST")).toBe("products");
+    expect(resolvePageListingLayout("PROFILELIST")).toBe("profiles");
   });
 
   it("leaves an ordinary page on the page layout", () => {
     expect(resolvePageListingLayout("CONTENT")).toBeNull();
     expect(resolvePageListingLayout("LINK")).toBeNull();
-  });
-
-  it("leaves a profile listing on the page layout, having no index for it", () => {
-    expect(resolvePageListingLayout("PROFILELIST")).toBeNull();
   });
 
   it("leaves a page type this template has never heard of on the page layout", () => {

--- a/src/components/utils/pageLayout.ts
+++ b/src/components/utils/pageLayout.ts
@@ -1,13 +1,13 @@
-export type PageListingLayout = "news" | "events" | "products";
+export type PageListingLayout = "news" | "events" | "products" | "profiles";
 
 // Keyed by PAGE_TYPE as `string`: the SDK's Page["type"] union stops at NEWSLIST.
-// PROFILELIST omitted — this template has no profiles index to stand in for.
 const LISTING_LAYOUT_BY_PAGE_TYPE: Partial<Record<string, PageListingLayout>> =
   {
     NEWS: "news",
     NEWSLIST: "news",
     EVENTLIST: "events",
     PRODUCTLIST: "products",
+    PROFILELIST: "profiles",
   };
 
 export const resolvePageListingLayout = (

--- a/src/components/utils/searchParams.test.ts
+++ b/src/components/utils/searchParams.test.ts
@@ -1,6 +1,34 @@
+import { MAX_PAGE } from "@venuecms/sdk-next";
 import { describe, expect, it } from "vitest";
 
-import { buildPageHref } from "./searchParams";
+import { buildPageHref, readPage } from "./searchParams";
+
+describe("readPage", () => {
+  it("reads the page the URL names", () => {
+    expect(readPage({ page: "3" })).toBe(3);
+  });
+
+  it("starts at the first page when the URL names none", () => {
+    expect(readPage({})).toBe(0);
+  });
+
+  it("takes the first of a repeated param, as a route would", () => {
+    expect(readPage({ page: ["1", "2"] })).toBe(1);
+  });
+
+  // Digits only. Number() would read "1e3" as the deepest offset the endpoint
+  // will scan and "-2" as a negative one; parseInt would take "12abc" for 12.
+  it.each(["not-a-page", "-2", "3abc", "2.5", "1e3", "", " 1"])(
+    "starts at the first page rather than sending %j to the endpoint",
+    (page) => {
+      expect(readPage({ page })).toBe(0);
+    },
+  );
+
+  it("clamps a hand-edited page to the deepest the endpoint will scan", () => {
+    expect(readPage({ page: String(MAX_PAGE + 5000) })).toBe(MAX_PAGE);
+  });
+});
 
 describe("buildPageHref", () => {
   it("pages against the path it was given", () => {

--- a/src/components/utils/searchParams.ts
+++ b/src/components/utils/searchParams.ts
@@ -1,4 +1,26 @@
-import type { SearchParams } from "@venuecms/sdk-next";
+import { MAX_PAGE, type SearchParams } from "@venuecms/sdk-next";
+
+/**
+ * The page a URL is asking for: the read half of the same concern
+ * `buildPageHref` writes, kept beside it so a pager's two ends cannot drift.
+ *
+ * Anything that is not a run of digits starts at the first page rather than
+ * reaching the endpoint. `Number()` would read "1e3" as the deepest offset the
+ * endpoint will scan and "-2" as a negative one; `parseInt` would take "12abc"
+ * for 12.
+ */
+export const readPage = (searchParams: SearchParams): number => {
+  const raw = searchParams.page;
+  const value = Array.isArray(raw) ? raw[0] : raw;
+
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    return 0;
+  }
+
+  // Clamped rather than passed on: a hand-edited page deeper than the endpoint
+  // will scan is a request it would refuse anyway.
+  return Math.min(Number(value), MAX_PAGE);
+};
 
 /**
  * A route pager's href, carrying every other param through.


### PR DESCRIPTION
A page typed Profile Listing renders the site roster instead of the generic page layout, completing the page-type layouts alongside events and products. It uses the two-column frame `/events` and `/archive` use, since this template has no `/profiles` route to mirror, and renders the page's own body above the records so a listing block in that body still paginates.

The profile grid is extracted as `ProfilesList` and the `profileListing` content block draws through it, so the listing page and an author's block cannot render the same roster two different ways. The page sends no `dir`/`orderBy` for the same reason: a block sends neither unless its author picks one.

A failed profiles read now throws rather than falling through to "No artists found" — the SDK reports a failed read as absent data, so an outage was served and cached as a roster that is genuinely empty. The heading and the body sit outside the Suspense and error boundaries, so neither waits on the roster fetch nor disappears when it fails. `PageListing`'s switch is now exhaustive, so a layout added without a case is a compile error rather than a blank page.

Stacked on #71, which added the same treatment for `NEWSLIST`/`EVENTLIST`/`PRODUCTLIST` and deliberately left `PROFILELIST` out. Rebase onto `dev` once that lands, or squash the two.

Two things a reviewer should know. The roster is one page of 99 with no pager, matching template-liminal and the cap `/events` already puts on its own index — records past it are not reachable from this page, and a pager is a follow-up rather than something this hides. And `Page`, `Event` and `Product` still inline the same profile grid; folding them into `ProfilesList` touches pages this branch does not otherwise change, so it is left out.

No `VENUE_API_KEY` in this environment, so this was not driven in a browser: verified with `pnpm typecheck` and `pnpm test` (122 passing, up from 105).