### PR TITLE
feat(pages): render listing layouts for listing page types (VEN-521, VEN-681)

### DIFF
--- a/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
@@ -1,11 +1,3 @@
-/**
- * The one thing only this route can get wrong: choosing a layout.
- *
- * `PageListing` is covered where it lives, and so is the type-to-layout map.
- * What neither sees is whether this segment consults the map at all — a page
- * typed as the site's event listing that quietly renders the page layout is a
- * blank-looking page, not an error.
- */
 import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
@@ -81,17 +73,12 @@ describe("the page route", () => {
   });
 
   it("still renders a listing when the page tree cannot be read", async () => {
-    // A listing draws from its own endpoint. Deciding the layout after the
-    // page-tree guard would 404 it over a read only the page layout needs —
-    // and the pages read is the one this route makes purely for subpages.
     expect(await renderRoute("PRODUCTLIST", true)).toContain(
       'data-testid="page-listing"',
     );
   });
 
   it("keeps a page typed as a listing this template has no index for", async () => {
-    // There is no profiles index here, so PROFILELIST resolves to no layout and
-    // the page renders its own content rather than nothing at all.
     expect(await renderRoute("PROFILELIST")).toContain(
       'data-testid="page-layout"',
     );

--- a/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * The one thing only this route can get wrong: choosing a layout.
+ *
+ * `PageListing` is covered where it lives, and so is the type-to-layout map.
+ * What neither sees is whether this segment consults the map at all — a page
+ * typed as the site's event listing that quietly renders the page layout is a
+ * blank-looking page, not an error.
+ */
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import PagePage from "./page";
+
+vi.mock("@/lib", () => ({ getGenerateMetadata: () => () => ({}) }));
+vi.mock("@/components/utils", () => ({ setupSSR: async () => {} }));
+vi.mock("@/components", () => ({
+  Page: () => <div data-testid="page-layout" />,
+}));
+vi.mock("@/components/PageListing", () => ({
+  PageListing: (props: Record<string, unknown>) => (
+    <div
+      data-testid="page-listing"
+      data-layout={typeof props.layout === "string" ? props.layout : undefined}
+      data-title={typeof props.title === "string" ? props.title : undefined}
+      data-base-path={
+        typeof props.basePath === "string" ? props.basePath : undefined
+      }
+    />
+  ),
+}));
+
+const { reads } = vi.hoisted(() => ({
+  reads: { pageType: "CONTENT", pagesReadFails: false },
+}));
+
+vi.mock("@venuecms/sdk-next", () => ({
+  getPage: async () => ({
+    data: { id: "p1", type: reads.pageType, localizedContent: [] },
+  }),
+  getPages: async () => ({
+    data: reads.pagesReadFails ? null : { records: [] },
+  }),
+  getLocalizedContent: () => ({ content: { title: "What's On" } }),
+}));
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(node);
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+const renderRoute = async (type: string, pagesReadFails = false) => {
+  reads.pageType = type;
+  reads.pagesReadFails = pagesReadFails;
+
+  return render(
+    await PagePage({
+      params: Promise.resolve({
+        siteKey: "a-site",
+        locale: "en",
+        slug: "whats-on",
+      }),
+      searchParams: Promise.resolve({ page: "2" }),
+    }),
+  );
+};
+
+describe("the page route", () => {
+  it("renders an ordinary page with the page layout", async () => {
+    expect(await renderRoute("CONTENT")).toContain('data-testid="page-layout"');
+  });
+
+  it("renders a listing page with its listing, paged against its own path", async () => {
+    const html = await renderRoute("EVENTLIST");
+
+    expect(html).not.toContain('data-testid="page-layout"');
+    expect(html).toContain('data-layout="events"');
+    expect(html).toContain('data-title="What&#x27;s On"');
+    expect(html).toContain('data-base-path="/p/whats-on"');
+  });
+
+  it("still renders a listing when the page tree cannot be read", async () => {
+    // A listing draws from its own endpoint. Deciding the layout after the
+    // page-tree guard would 404 it over a read only the page layout needs —
+    // and the pages read is the one this route makes purely for subpages.
+    expect(await renderRoute("PRODUCTLIST", true)).toContain(
+      'data-testid="page-listing"',
+    );
+  });
+
+  it("keeps a page typed as a listing this template has no index for", async () => {
+    // There is no profiles index here, so PROFILELIST resolves to no layout and
+    // the page renders its own content rather than nothing at all.
+    expect(await renderRoute("PROFILELIST")).toContain(
+      'data-testid="page-layout"',
+    );
+  });
+});

--- a/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
@@ -90,8 +90,15 @@ describe("the page route", () => {
     );
   });
 
-  it("keeps a page typed as a listing this template has no index for", async () => {
-    expect(await renderRoute("PROFILELIST")).toContain(
+  it("renders a profile listing page with its listing", async () => {
+    const html = await renderRoute("PROFILELIST");
+
+    expect(html).not.toContain('data-testid="page-layout"');
+    expect(html).toContain('data-layout="profiles"');
+  });
+
+  it("keeps a page type this template has no listing for on the page layout", async () => {
+    expect(await renderRoute("SOMETHING_NEW")).toContain(
       'data-testid="page-layout"',
     );
   });

--- a/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.test.tsx
@@ -10,7 +10,10 @@ vi.mock("@/components", () => ({
   Page: () => <div data-testid="page-layout" />,
 }));
 vi.mock("@/components/PageListing", () => ({
-  PageListing: (props: Record<string, unknown>) => (
+  PageListing: ({
+    content,
+    ...props
+  }: Record<string, unknown> & { content?: { content?: string | null } }) => (
     <div
       data-testid="page-listing"
       data-layout={typeof props.layout === "string" ? props.layout : undefined}
@@ -18,6 +21,7 @@ vi.mock("@/components/PageListing", () => ({
       data-base-path={
         typeof props.basePath === "string" ? props.basePath : undefined
       }
+      data-content={content?.content ?? undefined}
     />
   ),
 }));
@@ -33,7 +37,9 @@ vi.mock("@venuecms/sdk-next", () => ({
   getPages: async () => ({
     data: reads.pagesReadFails ? null : { records: [] },
   }),
-  getLocalizedContent: () => ({ content: { title: "What's On" } }),
+  getLocalizedContent: () => ({
+    content: { title: "What's On", content: "Season notes" },
+  }),
 }));
 
 const render = async (node: ReactNode) => {
@@ -70,6 +76,12 @@ describe("the page route", () => {
     expect(html).toContain('data-layout="events"');
     expect(html).toContain('data-title="What&#x27;s On"');
     expect(html).toContain('data-base-path="/p/whats-on"');
+  });
+
+  it("hands the listing the page's own content to render", async () => {
+    expect(await renderRoute("EVENTLIST")).toContain(
+      'data-content="Season notes"',
+    );
   });
 
   it("still renders a listing when the page tree cannot be read", async () => {

--- a/src/app/[siteKey]/[locale]/p/[slug]/page.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.tsx
@@ -38,10 +38,7 @@ const PagePage = async ({
       notFound();
     }
 
-    // A page typed as one of the site's listings renders that listing instead
-    // of its own content, so the index looks the same wherever an author puts
-    // it. Decided before the page tree is read at all: a listing draws from its
-    // own endpoint, and the tree is something only the page layout needs.
+    // Resolved before the page tree is read: only the page layout needs the tree.
     const listingLayout = resolvePageListingLayout(page.type);
 
     if (listingLayout) {
@@ -58,7 +55,6 @@ const PagePage = async ({
       );
     }
 
-    // The page layout draws the subpage tree, so it does need the page list.
     const { data: pages } = await getPages();
 
     if (!pages) {

--- a/src/app/[siteKey]/[locale]/p/[slug]/page.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { NewsView, Page } from "@/components";
+import { Page } from "@/components";
 import { getGenerateMetadata } from "@/lib";
 import { Params } from "@/types";
 import { type SearchParams, getLocalizedContent } from "@venuecms/sdk-next";
@@ -7,7 +7,9 @@ import { notFound } from "next/navigation";
 
 import { PageWithParent } from "@/lib/utils/tree";
 
+import { PageListing } from "@/components/PageListing";
 import { setupSSR } from "@/components/utils";
+import { resolvePageListingLayout } from "@/components/utils/pageLayout";
 
 export const generateMetadata = getGenerateMetadata(getPage);
 
@@ -31,20 +33,36 @@ const PagePage = async ({
 
   try {
     const { data: page } = await getPage({ slug });
-    const { data: pages } = await getPages();
 
-    if (!page || !pages) {
+    if (!page) {
       notFound();
     }
 
-    if (page.type === "NEWS" || page.type === "NEWSLIST") {
+    // A page typed as one of the site's listings renders that listing instead
+    // of its own content, so the index looks the same wherever an author puts
+    // it. Decided before the page tree is read at all: a listing draws from its
+    // own endpoint, and the tree is something only the page layout needs.
+    const listingLayout = resolvePageListingLayout(page.type);
+
+    if (listingLayout) {
       const { content } = getLocalizedContent(page.localizedContent, locale);
+
       return (
-        <NewsView
+        <PageListing
+          layout={listingLayout}
+          locale={locale}
           title={content.title ?? undefined}
+          basePath={`/p/${slug}`}
           searchParams={resolvedSearchParams}
         />
       );
+    }
+
+    // The page layout draws the subpage tree, so it does need the page list.
+    const { data: pages } = await getPages();
+
+    if (!pages) {
+      notFound();
     }
 
     return (

--- a/src/app/[siteKey]/[locale]/p/[slug]/page.tsx
+++ b/src/app/[siteKey]/[locale]/p/[slug]/page.tsx
@@ -49,6 +49,7 @@ const PagePage = async ({
           layout={listingLayout}
           locale={locale}
           title={content.title ?? undefined}
+          content={content}
           basePath={`/p/${slug}`}
           searchParams={resolvedSearchParams}
         />

--- a/src/app/[siteKey]/[locale]/shop/loading.tsx
+++ b/src/app/[siteKey]/[locale]/shop/loading.tsx
@@ -1,19 +1,11 @@
-import { Skeleton } from "@/components/ui/Input/Skeleton";
+import { ProductsLayout, ProductsListSkeleton } from "@/components/ShopPage";
 
+// The frame and the skeleton the listing itself uses, so the route transition
+// and the Suspense fallback behind it cannot disagree about the page's shape.
 export default function Loading() {
   return (
-    <section className="py-20">
-      <div className="grid gap-8 pb-20 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
-        {[1, 2, 3, 4].map((i) => (
-          <div key={i} className="flex flex-col gap-3">
-            <Skeleton className="aspect-square" />
-            <div className="flex flex-col gap-1">
-              <Skeleton className="h-3 w-1/2" />
-              <Skeleton className="w-3/4" />
-            </div>
-          </div>
-        ))}
-      </div>
-    </section>
+    <ProductsLayout>
+      <ProductsListSkeleton />
+    </ProductsLayout>
   );
 }

--- a/src/app/[siteKey]/[locale]/shop/page.tsx
+++ b/src/app/[siteKey]/[locale]/shop/page.tsx
@@ -1,26 +1,41 @@
 import { getGenerateMetadata } from "@/lib";
 import { Params } from "@/types";
-import { getPage } from "@venuecms/sdk-next";
+import { type SearchParams, getPage } from "@venuecms/sdk-next";
 
-import { ProductsListSection } from "@/components/ShopPage";
+import { ProductsLayout, ProductsListSection } from "@/components/ShopPage";
 import { setupSSR } from "@/components/utils";
+import { readPage } from "@/components/utils/searchParams";
 
 export const generateMetadata = getGenerateMetadata(() =>
   getPage({ slug: "shop" }),
 );
 
+/**
+ * The route composes the layout and the listing itself, the same way a
+ * PRODUCTLIST page ends up with a products block inside `ProductsLayout`. The
+ * layout holds no listing of its own, so this is the only thing that puts the
+ * two together for /shop.
+ */
 const ProductsPage = async ({
   params,
   searchParams,
 }: {
   params: Promise<Params>;
-  searchParams: Promise<{ page: string }>;
+  searchParams: Promise<SearchParams>;
 }) => {
   await setupSSR({ params });
 
-  const currentPage = parseInt((await searchParams)?.page as string, 10) || 0;
+  const resolvedSearchParams = await searchParams;
 
-  return <ProductsListSection currentPage={currentPage} basePath="/shop" />;
+  return (
+    <ProductsLayout>
+      <ProductsListSection
+        currentPage={readPage(resolvedSearchParams)}
+        basePath="/shop"
+        searchParams={resolvedSearchParams}
+      />
+    </ProductsLayout>
+  );
 };
 
 export default ProductsPage;

--- a/src/app/[siteKey]/[locale]/shop/page.tsx
+++ b/src/app/[siteKey]/[locale]/shop/page.tsx
@@ -21,7 +21,13 @@ const ProductsPage = async ({
 
   const currentPage = parseInt((await searchParams)?.page as string, 10) || 0;
 
-  return <ProductsListSection locale={locale} currentPage={currentPage} />;
+  return (
+    <ProductsListSection
+      locale={locale}
+      currentPage={currentPage}
+      basePath="/shop"
+    />
+  );
 };
 
 export default ProductsPage;

--- a/src/app/[siteKey]/[locale]/shop/page.tsx
+++ b/src/app/[siteKey]/[locale]/shop/page.tsx
@@ -16,18 +16,11 @@ const ProductsPage = async ({
   params: Promise<Params>;
   searchParams: Promise<{ page: string }>;
 }) => {
-  const { locale } = await params;
   await setupSSR({ params });
 
   const currentPage = parseInt((await searchParams)?.page as string, 10) || 0;
 
-  return (
-    <ProductsListSection
-      locale={locale}
-      currentPage={currentPage}
-      basePath="/shop"
-    />
-  );
+  return <ProductsListSection currentPage={currentPage} basePath="/shop" />;
 };
 
 export default ProductsPage;

--- a/src/components/EventsPage/EventsListContent.test.tsx
+++ b/src/components/EventsPage/EventsListContent.test.tsx
@@ -5,8 +5,13 @@ import { renderToReadableStream } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { EventsListContent } from "./EventsListContent";
+import { EventsListSection } from "./EventsListSection";
 
 vi.mock("next/server", () => ({ connection: async () => {} }));
+
+// ColumnLeft is emitted first, so a body moved into it still reads as "before
+// the events" unless the assertion names the column that should hold it.
+const columnRight = (html: string) => html.split('class="col-span-2')[1] ?? "";
 
 const render = async (node: ReactNode) => {
   const stream = await renderToReadableStream(
@@ -79,15 +84,31 @@ describe("the events listing heading", () => {
   });
 
   it("renders a body it was handed above the events", async () => {
-    const html = await render(
-      <EventsListContent locale="en" title="What's On">
-        <p>Season notes</p>
-      </EventsListContent>,
+    const column = columnRight(
+      await render(
+        <EventsListContent locale="en" title="What's On">
+          <p>Season notes</p>
+        </EventsListContent>,
+      ),
     );
 
-    expect(html.indexOf("Season notes")).toBeGreaterThan(-1);
-    expect(html.indexOf("Season notes")).toBeLessThan(
-      html.indexOf("No events found"),
+    expect(column.indexOf("Season notes")).toBeGreaterThan(-1);
+    expect(column.indexOf("Season notes")).toBeLessThan(
+      column.indexOf("No events found"),
     );
+  });
+});
+
+describe("the events listing section", () => {
+  it("hands the body it was given to the content it wraps", async () => {
+    const column = columnRight(
+      await render(
+        <EventsListSection locale="en" title="What's On">
+          <p>Season notes</p>
+        </EventsListSection>,
+      ),
+    );
+
+    expect(column).toContain("Season notes");
   });
 });

--- a/src/components/EventsPage/EventsListContent.test.tsx
+++ b/src/components/EventsPage/EventsListContent.test.tsx
@@ -4,7 +4,6 @@ import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { EventsListContent } from "./EventsListContent";
 import { EventsListSection } from "./EventsListSection";
 
 vi.mock("next/server", () => ({ connection: async () => {} }));
@@ -18,40 +17,66 @@ const render = async (node: ReactNode) => {
     <NextIntlClientProvider locale="en" messages={{}}>
       {node}
     </NextIntlClientProvider>,
+    // The list's boundary is expected to catch a failed read; without this the
+    // recoverable error still reaches the console and reads as a test error.
+    { onError: () => {} },
   );
   await stream.allReady;
   return new Response(stream).text();
 };
 
+const requestedUrls = () =>
+  vi
+    .mocked(globalThis.fetch)
+    .mock.calls.map(([input]) =>
+      input instanceof Request ? input.url : String(input),
+    );
+
+/** The title on the "events" page record, or null for a locale saved without one. */
+let recordTitle: string | null = "Upcoming Events";
+let siteReadFails = false;
+
 beforeEach(() => {
   setConfig({ siteKey: "test-site" });
+  recordTitle = "Upcoming Events";
+  siteReadFails = false;
 
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = input instanceof Request ? input.url : String(input);
 
-    let body: unknown = {
-      id: "site-id",
-      timeZone: "Europe/Berlin",
-      settings: {},
-    };
-
     // Pages first: /pages/events would otherwise match the events branch.
     if (url.includes("/pages")) {
-      body = {
-        id: "page-id",
-        slug: "events",
-        localizedContent: [
-          { siteId: "site-id", locale: "en", title: "Upcoming Events" },
-        ],
-      };
-    } else if (url.includes("/events")) {
-      body = { records: [], count: 0 };
+      return new Response(
+        JSON.stringify({
+          id: "page-id",
+          slug: "events",
+          localizedContent: [
+            { siteId: "site-id", locale: "en", title: recordTitle },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
     }
 
-    return new Response(JSON.stringify(body), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
+    if (url.includes("/events")) {
+      return new Response(JSON.stringify({ records: [], count: 0 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (siteReadFails) {
+      return new Response("upstream is down", { status: 500 });
+    }
+
+    return new Response(
+      JSON.stringify({
+        id: "site-id",
+        timeZone: "Europe/Berlin",
+        settings: {},
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
   });
 });
 
@@ -61,46 +86,45 @@ afterEach(() => {
 
 describe("the events listing heading", () => {
   it("reads the /events page record when no title was handed to it", async () => {
-    const html = await render(<EventsListContent locale="en" />);
-
-    expect(html).toContain("Upcoming Events");
+    expect(await render(<EventsListSection locale="en" />)).toContain(
+      "Upcoming Events",
+    );
   });
 
   it("prefers the title it was given, and does not read the page record", async () => {
     const html = await render(
-      <EventsListContent locale="en" title="What's On" />,
+      <EventsListSection locale="en" title="What's On" />,
     );
 
     expect(html).toContain("What&#x27;s On");
     expect(html).not.toContain("Upcoming Events");
-
-    const requested = vi
-      .mocked(globalThis.fetch)
-      .mock.calls.map(([input]) =>
-        input instanceof Request ? input.url : String(input),
-      );
-
-    expect(requested.some((url) => url.includes("/pages"))).toBe(false);
+    expect(requestedUrls().some((url) => url.includes("/pages"))).toBe(false);
   });
 
-  it("renders a body it was handed above the events", async () => {
-    const column = columnRight(
-      await render(
-        <EventsListContent locale="en" title="What's On">
-          <p>Season notes</p>
-        </EventsListContent>,
-      ),
-    );
+  // A locale saved without a title yields "", not undefined. Reading absence
+  // rather than emptiness would take "" for a title and draw a blank column —
+  // and would skip the page read whose answer it then ignored.
+  it.each([
+    ["an empty title", ""],
+    ["a whitespace-only title", "   "],
+  ])("reads the page record given %s", async (_label, title) => {
+    const html = await render(<EventsListSection locale="en" title={title} />);
 
-    expect(column.indexOf("Season notes")).toBeGreaterThan(-1);
-    expect(column.indexOf("Season notes")).toBeLessThan(
-      column.indexOf("No events found"),
+    expect(html).toContain("Upcoming Events");
+  });
+
+  // And the record's own title can be blank the same way.
+  it("falls back to a heading of its own when the record has none", async () => {
+    recordTitle = "";
+
+    expect(await render(<EventsListSection locale="en" />)).toContain(
+      "upcoming events",
     );
   });
 });
 
-describe("the events listing section", () => {
-  it("hands the body it was given to the content it wraps", async () => {
+describe("the events listing body", () => {
+  it("renders a body it was handed above the events", async () => {
     const column = columnRight(
       await render(
         <EventsListSection locale="en" title="What's On">
@@ -109,6 +133,31 @@ describe("the events listing section", () => {
       ),
     );
 
-    expect(column).toContain("Season notes");
+    expect(column.indexOf("Season notes")).toBeGreaterThan(-1);
+    expect(column.indexOf("Season notes")).toBeLessThan(
+      column.indexOf("No events found"),
+    );
+  });
+
+  // The heading and the body cost no request of their own, so they sit outside
+  // the boundaries: a failed list read has no business taking an author's prose
+  // or the page's title down with it.
+  //
+  // Asserted on what survives rather than on the error copy: the boundary that
+  // catches the bailout is a client component, and React hands a suspended
+  // boundary's error to the client rather than running its fallback in SSR.
+  it("keeps the title and the body when the list fails", async () => {
+    siteReadFails = true;
+
+    const html = await render(
+      <EventsListSection locale="en" title="What's On">
+        <p>Season notes</p>
+      </EventsListSection>,
+    );
+
+    expect(html).toContain("What&#x27;s On");
+    expect(html).toContain("Season notes");
+    // And does not pass the failure off as a listing that is merely empty.
+    expect(html).not.toContain("No events found");
   });
 });

--- a/src/components/EventsPage/EventsListContent.test.tsx
+++ b/src/components/EventsPage/EventsListContent.test.tsx
@@ -1,17 +1,3 @@
-/**
- * The heading, which is the one thing this listing reads that its caller can
- * now know better than it does.
- *
- * `/events` has no title of its own and looks the /events page record up for
- * one. A page typed as the event listing already holds the title an author
- * wrote, and a heading that ignored it would leave that page announcing itself
- * as whatever the /events record says — a wrong heading, not a missing one, so
- * nothing about it looks broken.
- *
- * `connection()` is stubbed for the same reason as in the shop's test: the
- * component calls it to opt out of the prerender and it throws outside a Next
- * request scope.
- */
 import { setConfig } from "@venuecms/sdk-next";
 import { NextIntlClientProvider } from "next-intl";
 import type { ReactNode } from "react";
@@ -44,8 +30,7 @@ beforeEach(() => {
       settings: {},
     };
 
-    // Pages first: the page record for this listing lives at /pages/events,
-    // which the events branch would otherwise swallow.
+    // Pages first: /pages/events would otherwise match the events branch.
     if (url.includes("/pages")) {
       body = {
         id: "page-id",

--- a/src/components/EventsPage/EventsListContent.test.tsx
+++ b/src/components/EventsPage/EventsListContent.test.tsx
@@ -77,4 +77,17 @@ describe("the events listing heading", () => {
 
     expect(requested.some((url) => url.includes("/pages"))).toBe(false);
   });
+
+  it("renders a body it was handed above the events", async () => {
+    const html = await render(
+      <EventsListContent locale="en" title="What's On">
+        <p>Season notes</p>
+      </EventsListContent>,
+    );
+
+    expect(html.indexOf("Season notes")).toBeGreaterThan(-1);
+    expect(html.indexOf("Season notes")).toBeLessThan(
+      html.indexOf("No events found"),
+    );
+  });
 });

--- a/src/components/EventsPage/EventsListContent.test.tsx
+++ b/src/components/EventsPage/EventsListContent.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * The heading, which is the one thing this listing reads that its caller can
+ * now know better than it does.
+ *
+ * `/events` has no title of its own and looks the /events page record up for
+ * one. A page typed as the event listing already holds the title an author
+ * wrote, and a heading that ignored it would leave that page announcing itself
+ * as whatever the /events record says — a wrong heading, not a missing one, so
+ * nothing about it looks broken.
+ *
+ * `connection()` is stubbed for the same reason as in the shop's test: the
+ * component calls it to opt out of the prerender and it throws outside a Next
+ * request scope.
+ */
+import { setConfig } from "@venuecms/sdk-next";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EventsListContent } from "./EventsListContent";
+
+vi.mock("next/server", () => ({ connection: async () => {} }));
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(
+    <NextIntlClientProvider locale="en" messages={{}}>
+      {node}
+    </NextIntlClientProvider>,
+  );
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+beforeEach(() => {
+  setConfig({ siteKey: "test-site" });
+
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = input instanceof Request ? input.url : String(input);
+
+    let body: unknown = {
+      id: "site-id",
+      timeZone: "Europe/Berlin",
+      settings: {},
+    };
+
+    // Pages first: the page record for this listing lives at /pages/events,
+    // which the events branch would otherwise swallow.
+    if (url.includes("/pages")) {
+      body = {
+        id: "page-id",
+        slug: "events",
+        localizedContent: [
+          { siteId: "site-id", locale: "en", title: "Upcoming Events" },
+        ],
+      };
+    } else if (url.includes("/events")) {
+      body = { records: [], count: 0 };
+    }
+
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("the events listing heading", () => {
+  it("reads the /events page record when no title was handed to it", async () => {
+    const html = await render(<EventsListContent locale="en" />);
+
+    expect(html).toContain("Upcoming Events");
+  });
+
+  it("prefers the title it was given, and does not read the page record", async () => {
+    const html = await render(
+      <EventsListContent locale="en" title="What's On" />,
+    );
+
+    expect(html).toContain("What&#x27;s On");
+    expect(html).not.toContain("Upcoming Events");
+
+    const requested = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.map(([input]) =>
+        input instanceof Request ? input.url : String(input),
+      );
+
+    expect(requested.some((url) => url.includes("/pages"))).toBe(false);
+  });
+});

--- a/src/components/EventsPage/EventsListContent.tsx
+++ b/src/components/EventsPage/EventsListContent.tsx
@@ -11,22 +11,14 @@ export async function EventsListContent({
   title,
 }: {
   locale: string;
-  /**
-   * The heading, when the caller already knows it.
-   *
-   * `/events` passes none and looks up the page record slugged "events" for
-   * one. A page typed as the event listing stands in for that route and holds
-   * the title an author actually wrote, so it passes its own — otherwise such
-   * a page would head itself with a title from a different record entirely.
-   */
+  /** Heading; a listing page passes its own, else the "events" record is read for one. */
   title?: string;
 }) {
   await connection();
 
   const [{ data: events }, { data: page }, { data: site }] = await Promise.all([
     getEvents({ limit: 60, upcoming: true }),
-    // Skipped when the caller brought a title: the page record is read for
-    // nothing else here.
+    // Read for the title only, so skipped when the caller brought one.
     title ? { data: null } : getPage({ slug: "events" }),
     getSite(),
   ]);

--- a/src/components/EventsPage/EventsListContent.tsx
+++ b/src/components/EventsPage/EventsListContent.tsx
@@ -4,24 +4,36 @@ import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
 import { EventsList, ListEvent } from "@/components/EventList";
-import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
 
-export async function EventsListContent({
-  locale,
-  title,
-  children,
-}: {
-  locale: string;
-  /** Heading; a listing page passes its own, else the "events" record is read for one. */
-  title?: string;
-  children?: React.ReactNode;
-}) {
+/**
+ * The heading a listing brings no title of its own: the "events" page record's.
+ *
+ * Its own component, and so its own boundary, because it is the one part of the
+ * left column that costs a request. A listing page passes its title straight in
+ * and this never renders.
+ */
+export async function EventsHeading({ locale }: { locale: string }) {
+  const { data: page } = await getPage({ slug: "events" });
+
+  const recordTitle = page
+    ? getLocalizedContent(page.localizedContent, locale).content.title
+    : null;
+
+  // Emptiness, not absence: a locale saved without a title yields "", which
+  // would otherwise draw a blank heading in place of the fallback.
+  return recordTitle?.trim() ? recordTitle : "upcoming events";
+}
+
+/**
+ * The records half of the events listing. Draws only the list: the frame, the
+ * heading and any page body live in `EventsListSection`, above the Suspense
+ * boundary, so none of them wait on this fetch or vanish with it.
+ */
+export async function EventsListContent() {
   await connection();
 
-  const [{ data: events }, { data: page }, { data: site }] = await Promise.all([
+  const [{ data: events }, { data: site }] = await Promise.all([
     getEvents({ limit: 60, upcoming: true }),
-    // Read for the title only, so skipped when the caller brought one.
-    title ? { data: null } : getPage({ slug: "events" }),
     getSite(),
   ]);
 
@@ -29,29 +41,13 @@ export async function EventsListContent({
     notFound();
   }
 
-  const pageTitle =
-    title ??
-    (page
-      ? getLocalizedContent(page.localizedContent, locale).content.title
-      : "upcoming events");
-
-  return (
-    <TwoColumnLayout>
-      <ColumnLeft className="text-sm text-secondary">
-        <p className="pb-8 text-primary">{pageTitle}</p>
-      </ColumnLeft>
-      <ColumnRight>
-        {children}
-        {events?.records.length ? (
-          <EventsList className="gap-y-12">
-            {events.records.map((event) => (
-              <ListEvent key={event.id} event={event} site={site} withImage />
-            ))}
-          </EventsList>
-        ) : (
-          "No events found"
-        )}
-      </ColumnRight>
-    </TwoColumnLayout>
+  return events?.records.length ? (
+    <EventsList className="gap-y-12">
+      {events.records.map((event) => (
+        <ListEvent key={event.id} event={event} site={site} withImage />
+      ))}
+    </EventsList>
+  ) : (
+    "No events found"
   );
 }

--- a/src/components/EventsPage/EventsListContent.tsx
+++ b/src/components/EventsPage/EventsListContent.tsx
@@ -9,10 +9,13 @@ import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
 export async function EventsListContent({
   locale,
   title,
+  children,
 }: {
   locale: string;
   /** Heading; a listing page passes its own, else the "events" record is read for one. */
   title?: string;
+  /** The page's body, above the events; absent on the `/events` route. */
+  children?: React.ReactNode;
 }) {
   await connection();
 
@@ -39,6 +42,7 @@ export async function EventsListContent({
         <p className="pb-8 text-primary">{pageTitle}</p>
       </ColumnLeft>
       <ColumnRight>
+        {children}
         {events?.records.length ? (
           <EventsList className="gap-y-12">
             {events.records.map((event) => (

--- a/src/components/EventsPage/EventsListContent.tsx
+++ b/src/components/EventsPage/EventsListContent.tsx
@@ -6,12 +6,28 @@ import { connection } from "next/server";
 import { EventsList, ListEvent } from "@/components/EventList";
 import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
 
-export async function EventsListContent({ locale }: { locale: string }) {
+export async function EventsListContent({
+  locale,
+  title,
+}: {
+  locale: string;
+  /**
+   * The heading, when the caller already knows it.
+   *
+   * `/events` passes none and looks up the page record slugged "events" for
+   * one. A page typed as the event listing stands in for that route and holds
+   * the title an author actually wrote, so it passes its own — otherwise such
+   * a page would head itself with a title from a different record entirely.
+   */
+  title?: string;
+}) {
   await connection();
 
   const [{ data: events }, { data: page }, { data: site }] = await Promise.all([
     getEvents({ limit: 60, upcoming: true }),
-    getPage({ slug: "events" }),
+    // Skipped when the caller brought a title: the page record is read for
+    // nothing else here.
+    title ? { data: null } : getPage({ slug: "events" }),
     getSite(),
   ]);
 
@@ -19,9 +35,11 @@ export async function EventsListContent({ locale }: { locale: string }) {
     notFound();
   }
 
-  const pageTitle = page
-    ? getLocalizedContent(page.localizedContent, locale).content.title
-    : "upcoming events";
+  const pageTitle =
+    title ??
+    (page
+      ? getLocalizedContent(page.localizedContent, locale).content.title
+      : "upcoming events");
 
   return (
     <TwoColumnLayout>

--- a/src/components/EventsPage/EventsListContent.tsx
+++ b/src/components/EventsPage/EventsListContent.tsx
@@ -2,17 +2,30 @@ import { getLocalizedContent } from "@venuecms/sdk-next";
 import { getEvents, getPage, getSite } from "@venuecms/sdk-next";
 import { notFound } from "next/navigation";
 import { connection } from "next/server";
+import type { ReactNode } from "react";
 
 import { EventsList, ListEvent } from "@/components/EventList";
+
+/** The one markup both spellings of the heading render, so they cannot drift. */
+export function EventsHeadingText({ children }: { children: ReactNode }) {
+  return <p className="pb-8 text-primary">{children}</p>;
+}
 
 /**
  * The heading a listing brings no title of its own: the "events" page record's.
  *
- * Its own component, and so its own boundary, because it is the one part of the
- * left column that costs a request. A listing page passes its title straight in
- * and this never renders.
+ * Its own component, and so its own boundaries, because it is the one part of
+ * the left column that costs a request. A listing page passes its title
+ * straight in and this never renders.
+ *
+ * It draws the whole `<p>` rather than returning bare text so that the pending
+ * and failed spellings of this slot are block elements too — a `<div>` skeleton
+ * inside the `<p>` would be invalid nesting, and the parser relocating it out
+ * breaks the sibling walk React uses to swap a resolved boundary in.
  */
 export async function EventsHeading({ locale }: { locale: string }) {
+  await connection();
+
   const { data: page } = await getPage({ slug: "events" });
 
   const recordTitle = page
@@ -21,7 +34,11 @@ export async function EventsHeading({ locale }: { locale: string }) {
 
   // Emptiness, not absence: a locale saved without a title yields "", which
   // would otherwise draw a blank heading in place of the fallback.
-  return recordTitle?.trim() ? recordTitle : "upcoming events";
+  return (
+    <EventsHeadingText>
+      {recordTitle?.trim() ? recordTitle : "upcoming events"}
+    </EventsHeadingText>
+  );
 }
 
 /**

--- a/src/components/EventsPage/EventsListContent.tsx
+++ b/src/components/EventsPage/EventsListContent.tsx
@@ -14,7 +14,6 @@ export async function EventsListContent({
   locale: string;
   /** Heading; a listing page passes its own, else the "events" record is read for one. */
   title?: string;
-  /** The page's body, above the events; absent on the `/events` route. */
   children?: React.ReactNode;
 }) {
   await connection();

--- a/src/components/EventsPage/EventsListSection.tsx
+++ b/src/components/EventsPage/EventsListSection.tsx
@@ -51,7 +51,6 @@ export function EventsListSection({
   title,
 }: {
   locale: string;
-  /** The heading, when the caller knows it. See {@link EventsListContent}. */
   title?: string;
 }) {
   return (

--- a/src/components/EventsPage/EventsListSection.tsx
+++ b/src/components/EventsPage/EventsListSection.tsx
@@ -53,7 +53,6 @@ export function EventsListSection({
 }: {
   locale: string;
   title?: string;
-  /** The page's body, above the events; absent on the `/events` route. */
   children?: React.ReactNode;
 }) {
   return (

--- a/src/components/EventsPage/EventsListSection.tsx
+++ b/src/components/EventsPage/EventsListSection.tsx
@@ -5,63 +5,77 @@ import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
 import { Skeleton } from "@/components/ui/Input/Skeleton";
 import { ErrorBoundary } from "@/components/utils/ErrorBoundary";
 
-import { EventsListContent } from "./EventsListContent";
+import { EventsHeading, EventsListContent } from "./EventsListContent";
 
 function EventsListError() {
   return (
-    <TwoColumnLayout>
-      <ColumnLeft className="text-sm text-secondary" />
-      <ColumnRight>
-        <p className="text-secondary">
-          Unable to load events. Please try refreshing the page.
-        </p>
-      </ColumnRight>
-    </TwoColumnLayout>
+    <p className="text-secondary">
+      Unable to load events. Please try refreshing the page.
+    </p>
   );
 }
 
 function EventsListSkeleton() {
   return (
-    <TwoColumnLayout>
-      <ColumnLeft className="text-sm text-secondary">
-        <div className="pb-8">
-          <Skeleton className="w-32" />
+    <EventsList className="gap-y-12">
+      {[1, 2, 3, 4, 5, 6].map((i) => (
+        <div key={i} className="flex flex-col gap-3 pb-8">
+          <Skeleton className="aspect-video w-full sm:w-80" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="w-32" />
+            <Skeleton className="w-48" />
+            <Skeleton className="w-24" />
+          </div>
         </div>
-      </ColumnLeft>
-      <ColumnRight>
-        <EventsList className="gap-y-12">
-          {[1, 2, 3, 4, 5, 6].map((i) => (
-            <div key={i} className="flex flex-col gap-3 pb-8">
-              <Skeleton className="aspect-video w-full sm:w-80" />
-              <div className="flex flex-col gap-1">
-                <Skeleton className="w-32" />
-                <Skeleton className="w-48" />
-                <Skeleton className="w-24" />
-              </div>
-            </div>
-          ))}
-        </EventsList>
-      </ColumnRight>
-    </TwoColumnLayout>
+      ))}
+    </EventsList>
   );
 }
 
+/**
+ * The frame of the events listing, shared by /events and by an EVENTLIST page.
+ *
+ * The page's own body sits *outside* the boundaries on purpose. It is already
+ * in hand and costs no request, so putting it under the Suspense would hide
+ * readable content behind the records' skeleton and shift the layout when they
+ * resolved, and putting it under the ErrorBoundary would delete an author's
+ * prose because an unrelated fetch failed. The heading is the same, except when
+ * it has to be read from the "events" record — then it gets a boundary of its
+ * own rather than sharing the records'.
+ */
 export function EventsListSection({
   locale,
   title,
   children,
 }: {
   locale: string;
+  /** Heading; a listing page passes its own, else the "events" record is read for one. */
   title?: string;
   children?: React.ReactNode;
 }) {
+  // Emptiness, not absence: a page saved without a title for this locale yields
+  // "", and `??` would keep it and draw an empty heading column.
+  const ownTitle = title?.trim() ? title : null;
+
   return (
-    <ErrorBoundary fallback={<EventsListError />}>
-      <Suspense fallback={<EventsListSkeleton />}>
-        <EventsListContent locale={locale} title={title}>
-          {children}
-        </EventsListContent>
-      </Suspense>
-    </ErrorBoundary>
+    <TwoColumnLayout>
+      <ColumnLeft className="text-sm text-secondary">
+        <p className="pb-8 text-primary">
+          {ownTitle ?? (
+            <Suspense fallback={<Skeleton className="w-32" />}>
+              <EventsHeading locale={locale} />
+            </Suspense>
+          )}
+        </p>
+      </ColumnLeft>
+      <ColumnRight>
+        {children}
+        <ErrorBoundary fallback={<EventsListError />}>
+          <Suspense fallback={<EventsListSkeleton />}>
+            <EventsListContent />
+          </Suspense>
+        </ErrorBoundary>
+      </ColumnRight>
+    </TwoColumnLayout>
   );
 }

--- a/src/components/EventsPage/EventsListSection.tsx
+++ b/src/components/EventsPage/EventsListSection.tsx
@@ -49,14 +49,19 @@ function EventsListSkeleton() {
 export function EventsListSection({
   locale,
   title,
+  children,
 }: {
   locale: string;
   title?: string;
+  /** The page's body, above the events; absent on the `/events` route. */
+  children?: React.ReactNode;
 }) {
   return (
     <ErrorBoundary fallback={<EventsListError />}>
       <Suspense fallback={<EventsListSkeleton />}>
-        <EventsListContent locale={locale} title={title} />
+        <EventsListContent locale={locale} title={title}>
+          {children}
+        </EventsListContent>
       </Suspense>
     </ErrorBoundary>
   );

--- a/src/components/EventsPage/EventsListSection.tsx
+++ b/src/components/EventsPage/EventsListSection.tsx
@@ -5,7 +5,11 @@ import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
 import { Skeleton } from "@/components/ui/Input/Skeleton";
 import { ErrorBoundary } from "@/components/utils/ErrorBoundary";
 
-import { EventsHeading, EventsListContent } from "./EventsListContent";
+import {
+  EventsHeading,
+  EventsHeadingText,
+  EventsListContent,
+} from "./EventsListContent";
 
 function EventsListError() {
   return (
@@ -60,13 +64,26 @@ export function EventsListSection({
   return (
     <TwoColumnLayout>
       <ColumnLeft className="text-sm text-secondary">
-        <p className="pb-8 text-primary">
-          {ownTitle ?? (
-            <Suspense fallback={<Skeleton className="w-32" />}>
+        {ownTitle ? (
+          <EventsHeadingText>{ownTitle}</EventsHeadingText>
+        ) : (
+          // Boundaries of its own, not the records': this read is the only one
+          // the left column makes, and an unreadable title has no business
+          // either waiting on the list or taking the route down with it.
+          <ErrorBoundary
+            fallback={<EventsHeadingText>upcoming events</EventsHeadingText>}
+          >
+            <Suspense
+              fallback={
+                <div className="pb-8">
+                  <Skeleton className="w-32" />
+                </div>
+              }
+            >
               <EventsHeading locale={locale} />
             </Suspense>
-          )}
-        </p>
+          </ErrorBoundary>
+        )}
       </ColumnLeft>
       <ColumnRight>
         {children}

--- a/src/components/EventsPage/EventsListSection.tsx
+++ b/src/components/EventsPage/EventsListSection.tsx
@@ -46,11 +46,18 @@ function EventsListSkeleton() {
   );
 }
 
-export function EventsListSection({ locale }: { locale: string }) {
+export function EventsListSection({
+  locale,
+  title,
+}: {
+  locale: string;
+  /** The heading, when the caller knows it. See {@link EventsListContent}. */
+  title?: string;
+}) {
   return (
     <ErrorBoundary fallback={<EventsListError />}>
       <Suspense fallback={<EventsListSkeleton />}>
-        <EventsListContent locale={locale} />
+        <EventsListContent locale={locale} title={title} />
       </Suspense>
     </ErrorBoundary>
   );

--- a/src/components/HomePage/ProductsContent.tsx
+++ b/src/components/HomePage/ProductsContent.tsx
@@ -32,12 +32,7 @@ export async function ProductsContent() {
       <div className="grid grid-cols-2 gap-8 pb-20 sm:max-w-full sm:grid-cols-4 xl:grid-cols-4">
         {topProducts?.length
           ? topProducts.map((product) => (
-              <ListProduct
-                key={product.slug}
-                featured={true}
-                product={product}
-                site={site}
-              />
+              <ListProduct key={product.slug} product={product} site={site} />
             ))
           : "No products found"}
       </div>

--- a/src/components/ListProduct/ProductsList.test.tsx
+++ b/src/components/ListProduct/ProductsList.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * The shop's product grid, now shared with the product listing block.
+ *
+ * The grid is the whole point of sharing: a block that drew products in a plain
+ * even grid looked nothing like /shop, which leads with four products in a wide
+ * track and runs the rest small. So the tracks are spelled out here rather than
+ * asserted loosely — a drift in either one is what this file exists to catch.
+ */
+import type { Product, Site } from "@venuecms/sdk-next";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ListingRoot } from "@/components/ListingBlock/ListingRoot";
+import { ProductListingBlock } from "@/components/ListingBlock/blocks";
+
+import { ProductsList } from "./index";
+
+const siteId = "site-id";
+
+const site: Site = { id: siteId, timeZone: "Europe/Berlin", settings: {} };
+
+const products = (count: number): Product[] =>
+  Array.from({ length: count }, (_, i) => ({
+    siteId,
+    slug: `p${i}`,
+    order: 0,
+    featured: false,
+    artists: [],
+    localizedContent: [{ siteId, locale: "en", title: `Product ${i}` }],
+  }));
+
+// ListProduct reads the locale off the provider.
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(
+    <NextIntlClientProvider locale="en" messages={{}}>
+      {node}
+    </NextIntlClientProvider>,
+  );
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+const REST_TRACK = "repeat(6,minmax(1rem,32rem))";
+
+describe("ProductsList", () => {
+  it("draws every product it was handed", async () => {
+    const html = await render(
+      <ProductsList products={products(6)} site={site} />,
+    );
+
+    expect(html).toContain("Product 0");
+    expect(html).toContain("Product 5");
+  });
+
+  // The shop's signature: four leading products in a four-column track, the
+  // rest in a six-column one.
+  it("leads with four products in a wider track", async () => {
+    const html = await render(
+      <ProductsList products={products(6)} site={site} />,
+    );
+
+    expect(html).toContain("xl:grid-cols-4");
+    expect(html).toContain(`xl:grid-cols-[${REST_TRACK}]`);
+  });
+
+  it("leads with the first four products, in order", async () => {
+    const html = await render(
+      <ProductsList products={products(6)} site={site} />,
+    );
+    const [lead, rest] = html.split(REST_TRACK);
+
+    expect(lead).toContain("Product 3");
+    expect(lead).not.toContain("Product 4");
+    expect(rest).toContain("Product 4");
+    // Positions, not just membership: a reversed lead holds the same four.
+    expect(lead.indexOf("Product 0")).toBeLessThan(lead.indexOf("Product 3"));
+    expect(rest.indexOf("Product 4")).toBeLessThan(rest.indexOf("Product 5"));
+  });
+
+  it("draws no second track when four or fewer products fit the first", async () => {
+    const html = await render(
+      <ProductsList products={products(4)} site={site} />,
+    );
+
+    expect(html).not.toContain("repeat(6");
+  });
+
+  // A gap between the tracks rather than padding under the first: a block that
+  // fills one track would otherwise trail a screenful of nothing into the prose
+  // under it.
+  it("keeps the tracks apart without padding under a single track", async () => {
+    const html = await render(
+      <ProductsList products={products(6)} site={site} />,
+    );
+
+    expect(html).toContain('class="flex flex-col gap-20"');
+    expect(html).not.toContain("pb-20");
+  });
+
+  it("takes the spacing its surroundings call for", async () => {
+    const html = await render(
+      <ProductsList products={products(1)} site={site} className="py-4" />,
+    );
+
+    expect(html).toContain('class="flex flex-col gap-20 py-4"');
+  });
+
+  /**
+   * The reason the grid was extracted at all: a product listing block used to
+   * draw its own plainer grid, so a products block on a page looked nothing
+   * like the products on /shop.
+   *
+   * Compared as markup rather than by class name, because that is what catches
+   * one of the two growing a wrapper the other has not. The block draws into
+   * `ListingRoot` — the element carrying `data-listing`, which is what exempts
+   * a listing from the page body's prose measure — so that is spelled out here
+   * rather than dropped from the comparison.
+   */
+  it("is what the product listing block draws", async () => {
+    const records = products(6);
+
+    expect(
+      await render(
+        <ProductListingBlock records={records} site={site} pagination={null} />,
+      ),
+    ).toBe(
+      await render(
+        <ListingRoot>
+          <ProductsList className="py-4" products={records} site={site} />
+        </ListingRoot>,
+      ),
+    );
+  });
+});

--- a/src/components/ListProduct/index.tsx
+++ b/src/components/ListProduct/index.tsx
@@ -6,15 +6,55 @@ import { cn } from "@/lib/utils";
 
 import { VenueImage } from "@/components/VenueImage";
 
+const LEAD_COUNT = 4;
+
+/**
+ * The shop's product grid, shared so a product listing block draws the same
+ * thing /shop does: the leading products in a four-column track, the rest in a
+ * six-column one, which is what makes the first row read as the larger one.
+ *
+ * The two tracks are held apart by a gap on the column between them rather than
+ * padding under the first. A block that fills only the first track sits
+ * mid-article, where trailing padding would open a screenful of nothing between
+ * the products and the prose under them.
+ */
+export const ProductsList = ({
+  products,
+  site,
+  className,
+}: {
+  products: Product[];
+  site: Site;
+  className?: string;
+}) => {
+  const lead = products.slice(0, LEAD_COUNT);
+  const rest = products.slice(LEAD_COUNT);
+
+  return (
+    <div className={cn("flex flex-col gap-20", className)}>
+      <div className="grid gap-8 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
+        {lead.map((product) => (
+          <ListProduct key={product.slug} product={product} site={site} />
+        ))}
+      </div>
+      {rest.length ? (
+        <div className="grid grid-cols-2 gap-8 sm:max-w-full lg:grid-cols-[repeat(4,minmax(1rem,32rem))] xl:grid-cols-[repeat(6,minmax(1rem,32rem))]">
+          {rest.map((product) => (
+            <ListProduct key={product.slug} product={product} site={site} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
 export const ListProduct = ({
   product,
   site,
-  featured,
   className,
 }: {
   product: Product;
   site: Site;
-  featured?: boolean;
   className?: string;
 }) => {
   const locale = useLocale();

--- a/src/components/ListingBlock/ListingRoot.tsx
+++ b/src/components/ListingBlock/ListingRoot.tsx
@@ -36,6 +36,34 @@ import type { ListingPagination } from "@venuecms/sdk-next";
 
 import { PaginationLinks } from "@/components/Pagination";
 
+/**
+ * The class names for a page body rendered through `contentComponents`.
+ *
+ * The readable measure is scoped to the body's *children* rather than the body
+ * itself, so a listing — which marks its root `data-listing` below — fills the
+ * layout the way the hardcoded /shop and /archive listings do, while the prose
+ * around it keeps a line length someone can read.
+ *
+ * It lives here rather than beside the body it styles because it is one half of
+ * a pair: `ListingRoot` is what opts a listing out of that selector, and the two
+ * only make sense read together.
+ */
+export const pageBodyStyles =
+  "flex flex-col gap-6 [&>*:not([data-listing])]:max-w-[42rem]";
+
+/**
+ * What every listing block draws itself into.
+ *
+ * One flex item rather than two, because a pager has to travel with the records
+ * it pages: left as siblings, a body that spaces its children apart would open
+ * the same gap between a listing and its own pager as between two paragraphs.
+ */
+export const ListingRoot = ({ children }: { children: React.ReactNode }) => (
+  <div data-listing className="flex flex-col gap-6">
+    {children}
+  </div>
+);
+
 export const PaginatedListing = ({
   pagination,
   records,
@@ -68,13 +96,13 @@ export const PaginatedListing = ({
     ) : null;
 
   if (!records.length) {
-    return links?.prevHref ? pager : null;
+    return links?.prevHref ? <ListingRoot>{pager}</ListingRoot> : null;
   }
 
   return (
-    <>
+    <ListingRoot>
       {children}
       {pager}
-    </>
+    </ListingRoot>
   );
 };

--- a/src/components/ListingBlock/blocks.tsx
+++ b/src/components/ListingBlock/blocks.tsx
@@ -30,8 +30,7 @@ import type { ListingProps } from "@venuecms/sdk-next";
 import { EventsList, ListEvent } from "@/components/EventList";
 import { ListProduct } from "@/components/ListProduct";
 import { ListPage, PagesList } from "@/components/PageList";
-import { ProfileCompact } from "@/components/ProfileCompact";
-import { TwoSubColumnLayout } from "@/components/layout";
+import { ProfilesList } from "@/components/ProfileList";
 import {
   resolveNewsArticleHref,
   resolvePageHref,
@@ -155,10 +154,6 @@ export const ProfileListingBlock = ({
   pagination,
 }: ListingProps<"profileListing">) => (
   <PaginatedListing pagination={pagination} records={records} label="Profiles">
-    <TwoSubColumnLayout className="py-4">
-      {records.map((profile) => (
-        <ProfileCompact key={profile.slug} profile={profile} />
-      ))}
-    </TwoSubColumnLayout>
+    <ProfilesList profiles={records} className="py-4" />
   </PaginatedListing>
 );

--- a/src/components/ListingBlock/blocks.tsx
+++ b/src/components/ListingBlock/blocks.tsx
@@ -28,7 +28,7 @@
 import type { ListingProps } from "@venuecms/sdk-next";
 
 import { EventsList, ListEvent } from "@/components/EventList";
-import { ListProduct } from "@/components/ListProduct";
+import { ProductsList } from "@/components/ListProduct";
 import { ListPage, PagesList } from "@/components/PageList";
 import { ProfilesList } from "@/components/ProfileList";
 import {
@@ -36,7 +36,7 @@ import {
   resolvePageHref,
 } from "@/components/utils/pageHref";
 
-import { PaginatedListing } from "./ListingPager";
+import { ListingRoot, PaginatedListing } from "./ListingRoot";
 
 export const EventListingBlock = ({
   records,
@@ -102,16 +102,18 @@ export const PageListingBlock = ({
   }
 
   return (
-    <PagesList className="py-4">
-      {records.map((page) => (
-        <ListPage
-          key={page.id}
-          page={page}
-          site={site}
-          {...resolvePageHref(page)}
-        />
-      ))}
-    </PagesList>
+    <ListingRoot>
+      <PagesList className="py-4">
+        {records.map((page) => (
+          <ListPage
+            key={page.id}
+            page={page}
+            site={site}
+            {...resolvePageHref(page)}
+          />
+        ))}
+      </PagesList>
+    </ListingRoot>
   );
 };
 
@@ -130,11 +132,9 @@ export const ProductListingBlock = ({
       records={records}
       label="Products"
     >
-      <div className="grid gap-8 py-4 sm:grid-cols-2 lg:grid-cols-3">
-        {records.map((product) => (
-          <ListProduct key={product.slug} product={product} site={site} />
-        ))}
-      </div>
+      {/* The shop's own grid, so a block reads as the listing /shop draws
+          rather than a second, plainer way of showing the same products. */}
+      <ProductsList className="py-4" products={records} site={site} />
     </PaginatedListing>
   );
 };

--- a/src/components/ListingBlock/index.tsx
+++ b/src/components/ListingBlock/index.tsx
@@ -22,6 +22,10 @@ import {
   ProfileListingBlock,
 } from "./blocks";
 
+// The class names a body rendered with these components belongs in: they scope
+// the readable measure so a listing among the prose fills the layout instead.
+export { pageBodyStyles } from "./ListingRoot";
+
 // Annotated with AllListingComponents as well, so a listing type added to the
 // contract fails to compile here until this template can render it — rather
 // than being dropped from published content with a console warning.

--- a/src/components/ListingBlock/integration.test.tsx
+++ b/src/components/ListingBlock/integration.test.tsx
@@ -26,7 +26,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { renderToReadableStream } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { contentComponents } from "./index";
+import { contentComponents, pageBodyStyles } from "./index";
 
 vi.mock("next/server", () => ({ connection: async () => {} }));
 
@@ -107,6 +107,96 @@ const render = async (node: React.ReactNode) => {
 
   return { html: await new Response(stream).text(), errors };
 };
+
+const VOID_TAGS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "source",
+  "track",
+  "wbr",
+]);
+
+/**
+ * How deeply the first `data-listing` element is nested inside the body
+ * container, or -1 if it is not in there at all. 0 means a direct child.
+ *
+ * Walked off the tag stream because there is no DOM implementation installed
+ * and the claim is structural: `pageBodyStyles` exempts listings with
+ * `[&>*:not([data-listing])]`, and `>` matches direct children only.
+ */
+const listingDepthInBody = (html: string) => {
+  // Matched on the part of the selector React does not escape, so this does not
+  // also become a test of HTML entity encoding.
+  const container = html.indexOf(":not([data-listing])]");
+
+  if (container === -1) {
+    return -1;
+  }
+
+  const tag = /<(\/?)([a-zA-Z][a-zA-Z0-9-]*)((?:"[^"]*"|[^>"])*?)(\/?)>/g;
+  tag.lastIndex = html.indexOf(">", container) + 1;
+
+  let depth = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = tag.exec(html))) {
+    const [, closing, name, attrs, selfClosing] = match;
+
+    if (closing) {
+      // Closing the container itself: the listing was never reached.
+      if (depth === 0) {
+        return -1;
+      }
+
+      depth -= 1;
+      continue;
+    }
+
+    if (attrs.includes("data-listing")) {
+      return depth;
+    }
+
+    if (!selfClosing && !VOID_TAGS.has(name)) {
+      depth += 1;
+    }
+  }
+
+  return -1;
+};
+
+/**
+ * The full-width mechanism rests on something this template does not control:
+ * the SDK rendering a block's `ListingRoot` as a *direct* child of the body it
+ * renders into. If the renderer ever wraps top-level nodes, `>` stops matching,
+ * every listing silently collapses to the prose measure, and no assertion made
+ * against the class string alone would notice.
+ */
+describe("a listing block inside a page body", () => {
+  it("is a direct child of the body, where the measure exempts it", async () => {
+    const { html } = await render(
+      <VenueContent
+        className={pageBodyStyles}
+        content={contentWith(
+          { type: "paragraph", content: [{ type: "text", text: "Notes" }] },
+          eventListing({ limit: 2 }),
+        )}
+        contentStyles={contentComponents}
+        searchParams={{}}
+      />,
+    );
+
+    expect(html).toContain("Notes");
+    expect(listingDepthInBody(html)).toBe(0);
+  });
+});
 
 describe("a listing block, end to end", () => {
   it("renders the endpoint's records through this template's list component", async () => {

--- a/src/components/News/NewsArticle.tsx
+++ b/src/components/News/NewsArticle.tsx
@@ -7,7 +7,9 @@ import {
 import { format } from "date-fns";
 import { getLocale } from "next-intl/server";
 
-import { contentComponents } from "@/components/ListingBlock";
+import { cn } from "@/lib/utils";
+
+import { contentComponents, pageBodyStyles } from "@/components/ListingBlock";
 import { VenueImage } from "@/components/VenueImage";
 
 import { ProfileCompact } from "../ProfileCompact";
@@ -58,7 +60,10 @@ export const NewsArticle = async ({
         {date ? <div className="text-sm text-muted">{date}</div> : null}
         {article.image ? <VenueImage image={article.image} /> : null}
         <VenueContent
-          className="flex max-w-[42rem] flex-col gap-6 text-sm"
+          // The measure sits on the prose, not the body: a listing block draws
+          // the same wide grid /shop does and would otherwise be crushed into
+          // a reading column.
+          className={cn(pageBodyStyles, "text-sm")}
           content={content}
           contentStyles={contentComponents}
           searchParams={searchParams}

--- a/src/components/Page/index.tsx
+++ b/src/components/Page/index.tsx
@@ -6,9 +6,10 @@ import {
 } from "@venuecms/sdk-next";
 import { useLocale } from "next-intl";
 
+import { cn } from "@/lib/utils";
 import { PageWithParent } from "@/lib/utils/tree";
 
-import { contentComponents } from "@/components/ListingBlock";
+import { contentComponents, pageBodyStyles } from "@/components/ListingBlock";
 import { VenueImage } from "@/components/VenueImage";
 
 import { PageTree } from "../PageTree";
@@ -56,7 +57,7 @@ export const Page = ({
 
       <ColumnRight>
         <VenueContent
-          className="flex max-w-[42rem] flex-col gap-6 text-sm"
+          className={cn(pageBodyStyles, "text-sm")}
           content={content}
           contentStyles={contentComponents}
           searchParams={searchParams}

--- a/src/components/PageListing/boundaries.test.tsx
+++ b/src/components/PageListing/boundaries.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Where a listing page's heading and body sit relative to its records' error
+ * boundary — the one thing every one of these views had to get right, and the
+ * one thing a plain SSR render cannot see.
+ *
+ * `ErrorBoundary` is a client component, and React hands a suspended boundary's
+ * error to the client rather than running its fallback while streaming. So a
+ * body nested *inside* the boundary still appears in the server output, and an
+ * assertion on that output passes whether the body is inside or outside it —
+ * which is exactly how the first spelling of these tests passed against the bug
+ * they were written to catch.
+ *
+ * Here the boundary is replaced by one that always draws its fallback, which is
+ * what "the records failed" looks like. Whatever still renders is what genuinely
+ * sits outside it, and a body that moves back under the boundary fails these.
+ */
+import type { SearchParams } from "@venuecms/sdk-next";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { EventsListSection } from "@/components/EventsPage";
+import { ProfilesListSection } from "@/components/ProfilesPage";
+import { ProductsListSection } from "@/components/ShopPage";
+
+vi.mock("next/server", () => ({ connection: async () => {} }));
+
+vi.mock("@/components/utils/ErrorBoundary", () => ({
+  ErrorBoundary: ({ fallback }: { fallback: ReactNode }) => fallback,
+}));
+
+// Nothing should reach the network: every records component this file renders
+// sits under the stubbed boundary and is replaced by its fallback.
+const fetchSpy = vi
+  .spyOn(globalThis, "fetch")
+  .mockImplementation(async () => new Response("{}"));
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(
+    <NextIntlClientProvider locale="en" messages={{}}>
+      {node}
+    </NextIntlClientProvider>,
+  );
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+const sections: Array<
+  [string, (props: { children: ReactNode }) => ReactNode, string]
+> = [
+  [
+    "events",
+    ({ children }) => (
+      <EventsListSection locale="en" title="What's On">
+        {children}
+      </EventsListSection>
+    ),
+    "What&#x27;s On",
+  ],
+  [
+    "profiles",
+    ({ children }) => (
+      <ProfilesListSection title="Artists" basePath="/p/roster" currentPage={0}>
+        {children}
+      </ProfilesListSection>
+    ),
+    "Artists",
+  ],
+];
+
+describe("a listing whose records failed", () => {
+  it.each(sections)(
+    "keeps the %s heading and body",
+    async (_name, Section, heading) => {
+      const html = await render(<Section>{<p>Season notes</p>}</Section>);
+
+      expect(html).toContain(heading);
+      expect(html).toContain("Season notes");
+    },
+  );
+
+  // The shop grid has no heading slot, so only its body is at stake.
+  it("keeps the products body", async () => {
+    const html = await render(
+      <ProductsListSection currentPage={0} basePath="/p/merch">
+        <p>Season notes</p>
+      </ProductsListSection>,
+    );
+
+    expect(html).toContain("Season notes");
+  });
+
+  it("draws each listing's own failure message in place of its records", async () => {
+    const searchParams: SearchParams = {};
+
+    expect(
+      await render(
+        <ProfilesListSection
+          title="Artists"
+          basePath="/p/roster"
+          currentPage={0}
+          searchParams={searchParams}
+        />,
+      ),
+    ).toContain("Unable to load artists");
+
+    expect(
+      await render(<EventsListSection locale="en" title="What's On" />),
+    ).toContain("Unable to load events");
+
+    expect(
+      await render(<ProductsListSection currentPage={0} basePath="/shop" />),
+    ).toContain("Unable to load products");
+  });
+
+  it("asks the network for nothing once the records are out of the way", () => {
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/PageListing/boundaries.test.tsx
+++ b/src/components/PageListing/boundaries.test.tsx
@@ -80,17 +80,12 @@ describe("a listing whose records failed", () => {
     },
   );
 
-  // The shop grid has no heading slot, so only its body is at stake.
-  it("keeps the products body", async () => {
-    const html = await render(
-      <ProductsListSection currentPage={0} basePath="/p/merch">
-        <p>Season notes</p>
-      </ProductsListSection>,
-    );
-
-    expect(html).toContain("Season notes");
-  });
-
+  /**
+   * Products are absent from the cases above because that layout wraps no body
+   * at all now: a PRODUCTLIST page's records come from a listing block in its
+   * own content, which sits outside anything `ProductsListSection` bounds. All
+   * that is left to pin for the shop is its failure message, below.
+   */
   it("draws each listing's own failure message in place of its records", async () => {
     const searchParams: SearchParams = {};
 

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * The dispatch itself, with the three listings stubbed.
+ *
+ * How a listing looks is covered where it lives — these are the same sections
+ * `/news`, `/events` and `/shop` render. What only this component can get wrong
+ * is which one a layout reaches, and the two things only `/p/<slug>` knows that
+ * have to survive the trip: the page's own title, and the path a pager builds
+ * hrefs against. The second fails quietly, paging a reader off to `/shop`.
+ */
+import { MAX_PAGE } from "@venuecms/sdk-next";
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { PageListing } from "./index";
+
+// A function declaration, not a const: the mock factories below run while the
+// hoisted `./index` import is resolved, before any top-level `const` on this
+// module has initialised.
+function stub(testId: string) {
+  return (props: Record<string, unknown>) => (
+    <div
+      data-testid={testId}
+      data-title={typeof props.title === "string" ? props.title : undefined}
+      data-base-path={
+        typeof props.basePath === "string" ? props.basePath : undefined
+      }
+      data-current-page={
+        typeof props.currentPage === "number"
+          ? String(props.currentPage)
+          : undefined
+      }
+    />
+  );
+}
+
+vi.mock("@/components/News", () => ({ NewsView: stub("news-view") }));
+vi.mock("@/components/EventsPage", () => ({
+  EventsListSection: stub("events-view"),
+}));
+vi.mock("@/components/ShopPage", () => ({
+  ProductsListSection: stub("products-view"),
+}));
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(node);
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+const renderListing = (props: Partial<Parameters<typeof PageListing>[0]>) =>
+  render(
+    <PageListing
+      layout="events"
+      locale="en"
+      basePath="/p/whats-on"
+      searchParams={{}}
+      {...props}
+    />,
+  );
+
+describe("PageListing", () => {
+  it.each([
+    ["news", "news-view"],
+    ["events", "events-view"],
+    ["products", "products-view"],
+  ] as const)("renders the %s listing", async (layout, testId) => {
+    expect(await renderListing({ layout })).toContain(
+      `data-testid="${testId}"`,
+    );
+  });
+
+  it.each([
+    ["news", "news-view"],
+    ["events", "events-view"],
+  ] as const)(
+    "gives the %s listing the page's own title",
+    async (layout, testId) => {
+      // Events as well as news: a title that reaches the dispatcher and is then
+      // dropped leaves an author's page announcing itself with whatever heading
+      // the static route reads for itself — a wrong title rather than a missing
+      // one, and nothing about that failure is visible at the call site.
+      const html = await renderListing({ layout, title: "Dispatches" });
+
+      expect(html).toContain(`data-testid="${testId}"`);
+      expect(html).toContain('data-title="Dispatches"');
+    },
+  );
+
+  it("gives the products listing no title, having nowhere to draw one", async () => {
+    // This template's shop is a bare grid on /shop too. Showing what an author
+    // wrote above the products is #66's job, not this dispatcher's.
+    const html = await renderListing({ layout: "products", title: "Merch" });
+
+    expect(html).toContain('data-testid="products-view"');
+    expect(html).not.toContain("data-title");
+  });
+
+  it("pages the products listing against the page it is rendered on", async () => {
+    const html = await renderListing({
+      layout: "products",
+      basePath: "/p/merch",
+      searchParams: { page: "2" },
+    });
+
+    expect(html).toContain('data-base-path="/p/merch"');
+    expect(html).toContain('data-current-page="2"');
+  });
+
+  it("takes the first of a repeated page param, as a route would", async () => {
+    // `parseInt` on the array reads "1,2" as 1 by accident. Reading the first
+    // value on purpose is the same rule the SDK's own pagers follow.
+    const html = await renderListing({
+      layout: "products",
+      searchParams: { page: ["1", "2"] },
+    });
+
+    expect(html).toContain('data-current-page="1"');
+  });
+
+  it("starts at the first page rather than fetching a nonsense one", async () => {
+    for (const page of ["not-a-page", "-2", "3abc", "2.5", "1e3", ""]) {
+      expect(
+        await renderListing({ layout: "products", searchParams: { page } }),
+      ).toContain('data-current-page="0"');
+    }
+
+    expect(
+      await renderListing({ layout: "products", searchParams: {} }),
+    ).toContain('data-current-page="0"');
+  });
+
+  it("clamps a hand-edited page rather than handing it to the endpoint", async () => {
+    // The endpoints page by offset, so an arbitrary number off the query string
+    // is an arbitrary offset for the database to walk. Clamping rather than
+    // resetting leaves the deepest reachable page a link back.
+    const html = await renderListing({
+      layout: "products",
+      searchParams: { page: String(MAX_PAGE + 5000) },
+    });
+
+    expect(html).toContain(`data-current-page="${MAX_PAGE}"`);
+  });
+});

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -1,12 +1,3 @@
-/**
- * The dispatch itself, with the three listings stubbed.
- *
- * How a listing looks is covered where it lives — these are the same sections
- * `/news`, `/events` and `/shop` render. What only this component can get wrong
- * is which one a layout reaches, and the two things only `/p/<slug>` knows that
- * have to survive the trip: the page's own title, and the path a pager builds
- * hrefs against. The second fails quietly, paging a reader off to `/shop`.
- */
 import { MAX_PAGE } from "@venuecms/sdk-next";
 import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
@@ -14,9 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { PageListing } from "./index";
 
-// A function declaration, not a const: the mock factories below run while the
-// hoisted `./index` import is resolved, before any top-level `const` on this
-// module has initialised.
+// Declaration, not const: mock factories run before this module's consts init.
 function stub(testId: string) {
   return (props: Record<string, unknown>) => (
     <div
@@ -76,10 +65,6 @@ describe("PageListing", () => {
   ] as const)(
     "gives the %s listing the page's own title",
     async (layout, testId) => {
-      // Events as well as news: a title that reaches the dispatcher and is then
-      // dropped leaves an author's page announcing itself with whatever heading
-      // the static route reads for itself — a wrong title rather than a missing
-      // one, and nothing about that failure is visible at the call site.
       const html = await renderListing({ layout, title: "Dispatches" });
 
       expect(html).toContain(`data-testid="${testId}"`);
@@ -88,8 +73,6 @@ describe("PageListing", () => {
   );
 
   it("gives the products listing no title, having nowhere to draw one", async () => {
-    // This template's shop is a bare grid on /shop too. Showing what an author
-    // wrote above the products is #66's job, not this dispatcher's.
     const html = await renderListing({ layout: "products", title: "Merch" });
 
     expect(html).toContain('data-testid="products-view"');
@@ -108,8 +91,6 @@ describe("PageListing", () => {
   });
 
   it("takes the first of a repeated page param, as a route would", async () => {
-    // `parseInt` on the array reads "1,2" as 1 by accident. Reading the first
-    // value on purpose is the same rule the SDK's own pagers follow.
     const html = await renderListing({
       layout: "products",
       searchParams: { page: ["1", "2"] },
@@ -131,9 +112,6 @@ describe("PageListing", () => {
   });
 
   it("clamps a hand-edited page rather than handing it to the endpoint", async () => {
-    // The endpoints page by offset, so an arbitrary number off the query string
-    // is an arbitrary offset for the database to walk. Clamping rather than
-    // resetting leaves the deepest reachable page a link back.
     const html = await renderListing({
       layout: "products",
       searchParams: { page: String(MAX_PAGE + 5000) },

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -14,22 +14,32 @@ function stub(testId: string) {
   return ({
     children,
     ...props
-  }: Record<string, unknown> & { children?: ReactNode }) => (
-    <div
-      data-testid={testId}
-      data-title={typeof props.title === "string" ? props.title : undefined}
-      data-base-path={
-        typeof props.basePath === "string" ? props.basePath : undefined
-      }
-      data-current-page={
-        typeof props.currentPage === "number"
-          ? String(props.currentPage)
-          : undefined
-      }
-    >
-      {children}
-    </div>
-  );
+  }: Record<string, unknown> & {
+    children?: ReactNode;
+    searchParams?: SearchParams;
+  }) => {
+    const blockParam = props.searchParams?.evt_9k3z1;
+
+    return (
+      <div
+        data-testid={testId}
+        data-title={typeof props.title === "string" ? props.title : undefined}
+        data-base-path={
+          typeof props.basePath === "string" ? props.basePath : undefined
+        }
+        data-current-page={
+          typeof props.currentPage === "number"
+            ? String(props.currentPage)
+            : undefined
+        }
+        data-block-param={
+          typeof blockParam === "string" ? blockParam : undefined
+        }
+      >
+        {children}
+      </div>
+    );
+  };
 }
 
 function contentStub({
@@ -67,11 +77,10 @@ vi.mock("@venuecms/sdk-next", async (importOriginal) => ({
   VenueContent: contentStub,
 }));
 
-const localizedContent = (content: string | null) => ({
-  siteId: "s1",
-  locale: "en",
-  content,
-});
+const localizedContent = (fields: {
+  content?: string | null;
+  contentJSON?: { [key: string]: unknown } | null;
+}) => ({ siteId: "s1", locale: "en", ...fields });
 
 // The stub views hold nothing but their children, so the markup up to the first
 // close tag is what a view was handed.
@@ -176,7 +185,7 @@ describe("PageListing", () => {
       const html = await renderListing({
         layout,
         searchParams: { page: "2" },
-        content: localizedContent("<p>Season notes</p>"),
+        content: localizedContent({ content: "<p>Season notes</p>" }),
       });
 
       const view = withinView(html, testId);
@@ -191,10 +200,28 @@ describe("PageListing", () => {
   // An empty block would leave the views spacing around nothing.
   it.each([
     ["no localized content", undefined],
-    ["an empty body", localizedContent(null)],
+    ["an empty body", localizedContent({ content: null })],
+    ["a whitespace-only body", localizedContent({ content: "   " })],
+    // What the editor saves for a body its author typed in and then cleared.
+    [
+      "an emptied editor doc",
+      localizedContent({
+        contentJSON: { type: "doc", content: [{ type: "paragraph" }] },
+      }),
+    ],
   ])("renders no content block for %s", async (_label, content) => {
     expect(await renderListing({ layout: "events", content })).not.toContain(
       'data-testid="page-content"',
     );
+  });
+
+  // The body's own listing block pages by a param of its own.
+  it("hands the products listing every param, not just the page", async () => {
+    const html = await renderListing({
+      layout: "products",
+      searchParams: { page: "1", evt_9k3z1: "3" },
+    });
+
+    expect(html).toContain('data-block-param="3"');
   });
 });

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -7,6 +7,8 @@ import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
+import { pageBodyStyles } from "@/components/ListingBlock";
+
 import { PageListing } from "./index";
 
 // Declaration, not const: mock factories run before this module's consts init.
@@ -43,20 +45,28 @@ function stub(testId: string) {
 }
 
 function contentStub({
+  className,
   contentStyles,
   searchParams,
 }: {
+  className?: string;
   contentStyles?: ContentEntries;
   searchParams?: SearchParams;
 }) {
   return (
     <div
       data-testid="page-content"
+      data-class-name={className}
       data-content-styles={
         typeof contentStyles?.p === "string" ? contentStyles.p : undefined
       }
       data-search-page={
         typeof searchParams?.page === "string" ? searchParams.page : undefined
+      }
+      data-block-param={
+        typeof searchParams?.evt_9k3z1 === "string"
+          ? searchParams.evt_9k3z1
+          : undefined
       }
     />
   );
@@ -66,13 +76,19 @@ vi.mock("@/components/News", () => ({ NewsView: stub("news-view") }));
 vi.mock("@/components/EventsPage", () => ({
   EventsListSection: stub("events-view"),
 }));
+// `ProductsListSection` is stubbed although the layout no longer renders it, so
+// a layout that reaches for the shop's records again shows up as a failure here
+// rather than as a second grid under the author's own products block.
 vi.mock("@/components/ShopPage", () => ({
-  ProductsListSection: stub("products-view"),
+  ProductsLayout: stub("products-layout"),
+  ProductsListSection: stub("products-records"),
 }));
 vi.mock("@/components/ProfilesPage", () => ({
   ProfilesListSection: stub("profiles-view"),
 }));
-vi.mock("@/components/ListingBlock", () => ({
+// Partial, so the real `pageBodyStyles` is what the body is checked against.
+vi.mock("@/components/ListingBlock", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/components/ListingBlock")>()),
   contentComponents: { p: "prose" },
 }));
 vi.mock("@venuecms/sdk-next", async (importOriginal) => ({
@@ -85,10 +101,23 @@ const localizedContent = (fields: {
   contentJSON?: { [key: string]: unknown } | null;
 }) => ({ siteId: "s1", locale: "en", ...fields });
 
+const body = localizedContent({ content: "<p>Season notes</p>" });
+
 // The stub views hold nothing but their children, so the markup up to the first
 // close tag is what a view was handed.
 const withinView = (html: string, testId: string) =>
   html.split(`data-testid="${testId}"`)[1]?.split("</div>")[0] ?? "";
+
+// Unescaped, because the arbitrary-variant selector these class names carry is
+// full of characters React escapes on the way into an attribute.
+const attr = (html: string, name: string) =>
+  html
+    .match(new RegExp(`data-${name}="([^"]*)"`))?.[1]
+    .replaceAll("&gt;", ">")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#x27;", "'")
+    .replaceAll("&amp;", "&");
 
 const render = async (node: ReactNode) => {
   const stream = await renderToReadableStream(node);
@@ -111,10 +140,10 @@ describe("PageListing", () => {
   it.each([
     ["news", "news-view"],
     ["events", "events-view"],
-    ["products", "products-view"],
+    ["products", "products-layout"],
     ["profiles", "profiles-view"],
   ] as const)("renders the %s listing", async (layout, testId) => {
-    expect(await renderListing({ layout })).toContain(
+    expect(await renderListing({ layout, content: body })).toContain(
       `data-testid="${testId}"`,
     );
   });
@@ -133,34 +162,41 @@ describe("PageListing", () => {
     },
   );
 
-  it("gives the products listing no title, having nowhere to draw one", async () => {
+  it("gives the products layout no title, having nowhere to draw one", async () => {
     const html = await renderListing({ layout: "products", title: "Merch" });
 
-    expect(html).toContain('data-testid="products-view"');
-    expect(html).not.toContain("data-title");
+    expect(html).toContain('data-testid="products-layout"');
+    expect(html).not.toContain('data-title="Merch"');
   });
 
-  it.each([
-    ["products", "products-view"],
-    ["profiles", "profiles-view"],
-  ] as const)(
-    "pages the %s listing against the page it is rendered on",
-    async (layout, testId) => {
-      const html = await renderListing({
-        layout,
-        basePath: "/p/merch",
-        searchParams: { page: "2" },
-      });
+  /**
+   * The point of the whole split. A PRODUCTLIST page is an ordinary page whose
+   * body holds a product listing block, so the layout is a frame and nothing
+   * more — a listing fetched here would stack a second grid under the author's.
+   */
+  it("draws no products of its own, leaving them to the body's block", async () => {
+    const html = await renderListing({ layout: "products", content: body });
 
-      expect(html).toContain(`data-testid="${testId}"`);
-      expect(html).toContain('data-base-path="/p/merch"');
-      expect(html).toContain('data-current-page="2"');
-    },
-  );
+    expect(html).not.toContain('data-testid="products-records"');
+    expect(withinView(html, "products-layout")).toContain(
+      'data-testid="page-content"',
+    );
+  });
+
+  it("pages the profiles listing against the page it is rendered on", async () => {
+    const html = await renderListing({
+      layout: "profiles",
+      basePath: "/p/roster",
+      searchParams: { page: "2" },
+    });
+
+    expect(html).toContain('data-base-path="/p/roster"');
+    expect(html).toContain('data-current-page="2"');
+  });
 
   it("takes the first of a repeated page param, as a route would", async () => {
     const html = await renderListing({
-      layout: "products",
+      layout: "profiles",
       searchParams: { page: ["1", "2"] },
     });
 
@@ -170,18 +206,18 @@ describe("PageListing", () => {
   it("starts at the first page rather than fetching a nonsense one", async () => {
     for (const page of ["not-a-page", "-2", "3abc", "2.5", "1e3", ""]) {
       expect(
-        await renderListing({ layout: "products", searchParams: { page } }),
+        await renderListing({ layout: "profiles", searchParams: { page } }),
       ).toContain('data-current-page="0"');
     }
 
     expect(
-      await renderListing({ layout: "products", searchParams: {} }),
+      await renderListing({ layout: "profiles", searchParams: {} }),
     ).toContain('data-current-page="0"');
   });
 
   it("clamps a hand-edited page rather than handing it to the endpoint", async () => {
     const html = await renderListing({
-      layout: "products",
+      layout: "profiles",
       searchParams: { page: String(MAX_PAGE + 5000) },
     });
 
@@ -190,7 +226,7 @@ describe("PageListing", () => {
 
   it.each([
     ["events", "events-view"],
-    ["products", "products-view"],
+    ["products", "products-layout"],
     ["profiles", "profiles-view"],
   ] as const)(
     "renders the page's own content inside the %s listing",
@@ -198,7 +234,7 @@ describe("PageListing", () => {
       const html = await renderListing({
         layout,
         searchParams: { page: "2" },
-        content: localizedContent({ content: "<p>Season notes</p>" }),
+        content: body,
       });
 
       const view = withinView(html, testId);
@@ -209,6 +245,19 @@ describe("PageListing", () => {
       expect(view).toContain('data-search-page="2"');
     },
   );
+
+  /**
+   * The measure has to sit on the body's children rather than the body, or the
+   * products block an author placed on a PRODUCTLIST page is capped at prose
+   * width instead of filling the layout the way /shop's own grid does.
+   */
+  it("scopes the readable measure to the prose, so a block fills the layout", async () => {
+    const html = await renderListing({ layout: "products", content: body });
+    const className = attr(html, "class-name") ?? "";
+
+    expect(className).toContain(pageBodyStyles);
+    expect(pageBodyStyles).toContain("[&>*:not([data-listing])]:max-w-");
+  });
 
   // An empty block would leave the views spacing around nothing.
   it.each([
@@ -229,9 +278,10 @@ describe("PageListing", () => {
   });
 
   // The body's own listing block pages by a param of its own.
-  it("hands the products listing every param, not just the page", async () => {
+  it("hands the body every param, not just the page", async () => {
     const html = await renderListing({
       layout: "products",
+      content: body,
       searchParams: { page: "1", evt_9k3z1: "3" },
     });
 

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -56,7 +56,12 @@ function contentStub({
   return (
     <div
       data-testid="page-content"
-      data-class-name={className}
+      // Compared here rather than round-tripped through an attribute: the class
+      // string is full of characters React escapes, and a test that had to
+      // un-escape them would be debugging entities instead of layout.
+      data-measure-scoped={
+        className?.includes(pageBodyStyles) ? "yes" : undefined
+      }
       data-content-styles={
         typeof contentStyles?.p === "string" ? contentStyles.p : undefined
       }
@@ -108,17 +113,6 @@ const body = localizedContent({ content: "<p>Season notes</p>" });
 const withinView = (html: string, testId: string) =>
   html.split(`data-testid="${testId}"`)[1]?.split("</div>")[0] ?? "";
 
-// Unescaped, because the arbitrary-variant selector these class names carry is
-// full of characters React escapes on the way into an attribute.
-const attr = (html: string, name: string) =>
-  html
-    .match(new RegExp(`data-${name}="([^"]*)"`))?.[1]
-    .replaceAll("&gt;", ">")
-    .replaceAll("&lt;", "<")
-    .replaceAll("&quot;", '"')
-    .replaceAll("&#x27;", "'")
-    .replaceAll("&amp;", "&");
-
 const render = async (node: ReactNode) => {
   const stream = await renderToReadableStream(node);
   await stream.allReady;
@@ -163,7 +157,11 @@ describe("PageListing", () => {
   );
 
   it("gives the products layout no title, having nowhere to draw one", async () => {
-    const html = await renderListing({ layout: "products", title: "Merch" });
+    const html = await renderListing({
+      layout: "products",
+      title: "Merch",
+      content: body,
+    });
 
     expect(html).toContain('data-testid="products-layout"');
     expect(html).not.toContain('data-title="Merch"');
@@ -250,14 +248,19 @@ describe("PageListing", () => {
    * The measure has to sit on the body's children rather than the body, or the
    * products block an author placed on a PRODUCTLIST page is capped at prose
    * width instead of filling the layout the way /shop's own grid does.
+   *
+   * That the selector actually reaches the block is a separate claim, pinned
+   * against the real renderer in `ListingBlock/integration.test.tsx` — this one
+   * only checks the body is styled with it at all.
    */
-  it("scopes the readable measure to the prose, so a block fills the layout", async () => {
-    const html = await renderListing({ layout: "products", content: body });
-    const className = attr(html, "class-name") ?? "";
+  it.each(["events", "products", "profiles"] as const)(
+    "styles the %s body so a listing escapes the prose measure",
+    async (layout) => {
+      const html = await renderListing({ layout, content: body });
 
-    expect(className).toContain(pageBodyStyles);
-    expect(pageBodyStyles).toContain("[&>*:not([data-listing])]:max-w-");
-  });
+      expect(html).toContain('data-measure-scoped="yes"');
+    },
+  );
 
   // An empty block would leave the views spacing around nothing.
   it.each([
@@ -275,6 +278,17 @@ describe("PageListing", () => {
     expect(await renderListing({ layout: "events", content })).not.toContain(
       'data-testid="page-content"',
     );
+  });
+
+  // The frame holds nothing but the body, so with no body it is a bare section
+  // of padding on a page that used to draw a grid.
+  it("draws no products frame at all for a body with nothing in it", async () => {
+    const html = await renderListing({
+      layout: "products",
+      content: undefined,
+    });
+
+    expect(html).not.toContain('data-testid="products-layout"');
   });
 
   // The body's own listing block pages by a param of its own.

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -1,4 +1,8 @@
-import { MAX_PAGE } from "@venuecms/sdk-next";
+import {
+  type ContentEntries,
+  MAX_PAGE,
+  type SearchParams,
+} from "@venuecms/sdk-next";
 import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
@@ -7,7 +11,10 @@ import { PageListing } from "./index";
 
 // Declaration, not const: mock factories run before this module's consts init.
 function stub(testId: string) {
-  return (props: Record<string, unknown>) => (
+  return ({
+    children,
+    ...props
+  }: Record<string, unknown> & { children?: ReactNode }) => (
     <div
       data-testid={testId}
       data-title={typeof props.title === "string" ? props.title : undefined}
@@ -18,6 +25,28 @@ function stub(testId: string) {
         typeof props.currentPage === "number"
           ? String(props.currentPage)
           : undefined
+      }
+    >
+      {children}
+    </div>
+  );
+}
+
+function contentStub({
+  contentStyles,
+  searchParams,
+}: {
+  contentStyles?: ContentEntries;
+  searchParams?: SearchParams;
+}) {
+  return (
+    <div
+      data-testid="page-content"
+      data-content-styles={
+        typeof contentStyles?.p === "string" ? contentStyles.p : undefined
+      }
+      data-search-page={
+        typeof searchParams?.page === "string" ? searchParams.page : undefined
       }
     />
   );
@@ -30,6 +59,24 @@ vi.mock("@/components/EventsPage", () => ({
 vi.mock("@/components/ShopPage", () => ({
   ProductsListSection: stub("products-view"),
 }));
+vi.mock("@/components/ListingBlock", () => ({
+  contentComponents: { p: "prose" },
+}));
+vi.mock("@venuecms/sdk-next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@venuecms/sdk-next")>()),
+  VenueContent: contentStub,
+}));
+
+const localizedContent = (content: string | null) => ({
+  siteId: "s1",
+  locale: "en",
+  content,
+});
+
+// The stub views hold nothing but their children, so the markup up to the first
+// close tag is what a view was handed.
+const withinView = (html: string, testId: string) =>
+  html.split(`data-testid="${testId}"`)[1]?.split("</div>")[0] ?? "";
 
 const render = async (node: ReactNode) => {
   const stream = await renderToReadableStream(node);
@@ -118,5 +165,36 @@ describe("PageListing", () => {
     });
 
     expect(html).toContain(`data-current-page="${MAX_PAGE}"`);
+  });
+
+  it.each([
+    ["events", "events-view"],
+    ["products", "products-view"],
+  ] as const)(
+    "renders the page's own content inside the %s listing",
+    async (layout, testId) => {
+      const html = await renderListing({
+        layout,
+        searchParams: { page: "2" },
+        content: localizedContent("<p>Season notes</p>"),
+      });
+
+      const view = withinView(html, testId);
+
+      expect(view).toContain('data-testid="page-content"');
+      // The content's own listing blocks need the styles and the page's params.
+      expect(view).toContain('data-content-styles="prose"');
+      expect(view).toContain('data-search-page="2"');
+    },
+  );
+
+  // An empty block would leave the views spacing around nothing.
+  it.each([
+    ["no localized content", undefined],
+    ["an empty body", localizedContent(null)],
+  ])("renders no content block for %s", async (_label, content) => {
+    expect(await renderListing({ layout: "events", content })).not.toContain(
+      'data-testid="page-content"',
+    );
   });
 });

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -140,16 +140,23 @@ describe("PageListing", () => {
     expect(html).not.toContain("data-title");
   });
 
-  it("pages the products listing against the page it is rendered on", async () => {
-    const html = await renderListing({
-      layout: "products",
-      basePath: "/p/merch",
-      searchParams: { page: "2" },
-    });
+  it.each([
+    ["products", "products-view"],
+    ["profiles", "profiles-view"],
+  ] as const)(
+    "pages the %s listing against the page it is rendered on",
+    async (layout, testId) => {
+      const html = await renderListing({
+        layout,
+        basePath: "/p/merch",
+        searchParams: { page: "2" },
+      });
 
-    expect(html).toContain('data-base-path="/p/merch"');
-    expect(html).toContain('data-current-page="2"');
-  });
+      expect(html).toContain(`data-testid="${testId}"`);
+      expect(html).toContain('data-base-path="/p/merch"');
+      expect(html).toContain('data-current-page="2"');
+    },
+  );
 
   it("takes the first of a repeated page param, as a route would", async () => {
     const html = await renderListing({

--- a/src/components/PageListing/index.test.tsx
+++ b/src/components/PageListing/index.test.tsx
@@ -69,6 +69,9 @@ vi.mock("@/components/EventsPage", () => ({
 vi.mock("@/components/ShopPage", () => ({
   ProductsListSection: stub("products-view"),
 }));
+vi.mock("@/components/ProfilesPage", () => ({
+  ProfilesListSection: stub("profiles-view"),
+}));
 vi.mock("@/components/ListingBlock", () => ({
   contentComponents: { p: "prose" },
 }));
@@ -109,6 +112,7 @@ describe("PageListing", () => {
     ["news", "news-view"],
     ["events", "events-view"],
     ["products", "products-view"],
+    ["profiles", "profiles-view"],
   ] as const)("renders the %s listing", async (layout, testId) => {
     expect(await renderListing({ layout })).toContain(
       `data-testid="${testId}"`,
@@ -118,6 +122,7 @@ describe("PageListing", () => {
   it.each([
     ["news", "news-view"],
     ["events", "events-view"],
+    ["profiles", "profiles-view"],
   ] as const)(
     "gives the %s listing the page's own title",
     async (layout, testId) => {
@@ -179,6 +184,7 @@ describe("PageListing", () => {
   it.each([
     ["events", "events-view"],
     ["products", "products-view"],
+    ["profiles", "profiles-view"],
   ] as const)(
     "renders the page's own content inside the %s listing",
     async (layout, testId) => {

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -57,7 +57,6 @@ export const PageListing = ({
     case "products":
       return (
         <ProductsListSection
-          locale={locale}
           basePath={basePath}
           currentPage={readPage(searchParams)}
           searchParams={searchParams}

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -5,11 +5,13 @@ import {
   VenueContent,
 } from "@venuecms/sdk-next";
 
+import { cn } from "@/lib/utils";
+
 import { EventsListSection } from "@/components/EventsPage";
-import { contentComponents } from "@/components/ListingBlock";
+import { contentComponents, pageBodyStyles } from "@/components/ListingBlock";
 import { NewsView } from "@/components/News";
 import { ProfilesListSection } from "@/components/ProfilesPage";
-import { ProductsListSection } from "@/components/ShopPage";
+import { ProductsLayout } from "@/components/ShopPage";
 import { hasRenderableContent } from "@/components/utils/pageContent";
 import type { PageListingLayout } from "@/components/utils/pageLayout";
 import { readPage } from "@/components/utils/searchParams";
@@ -36,7 +38,9 @@ export const PageListing = ({
   const body =
     content && hasRenderableContent(content) ? (
       <VenueContent
-        className="flex max-w-[42rem] flex-col gap-6 text-sm"
+        // The measure sits on the prose, not the body, so a listing block in it
+        // fills the layout the way the hardcoded listings do.
+        className={cn(pageBodyStyles, "text-sm")}
         content={content}
         contentStyles={contentComponents}
         searchParams={searchParams}
@@ -53,17 +57,10 @@ export const PageListing = ({
           {body}
         </EventsListSection>
       );
-    // No title: the shop grid has no heading slot.
+    // Frame only, and no title: /shop draws no heading, and the records are the
+    // body's own product listing block, not a second grid fetched here.
     case "products":
-      return (
-        <ProductsListSection
-          basePath={basePath}
-          currentPage={readPage(searchParams)}
-          searchParams={searchParams}
-        >
-          {body}
-        </ProductsListSection>
-      );
+      return <ProductsLayout>{body}</ProductsLayout>;
     // The events frame, which is also the archive's: with no /profiles route to
     // mirror, the index layout this template already uses is the one to match.
     case "profiles":

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -81,8 +81,13 @@ export const PageListing = ({
     // The events frame, which is also the archive's: with no /profiles route to
     // mirror, the index layout this template already uses is the one to match.
     case "profiles":
-      return (
-        <ProfilesListSection title={title}>{body}</ProfilesListSection>
-      );
+      return <ProfilesListSection title={title}>{body}</ProfilesListSection>;
   }
+
+  // A layout added to the union without a case above is a compile error here
+  // rather than a page that renders nothing: React accepts an undefined return,
+  // so falling off this switch would be silent at runtime and at typecheck.
+  layout satisfies never;
+
+  return null;
 };

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -1,19 +1,4 @@
-/**
- * The listing a page renders in place of its own content.
- *
- * A page marked in the CMS as the site's news / events / products index shows
- * that index, not the page layout — which is what lets an author put the index
- * anywhere in the tree and still have it look like `/events`. The dispatch
- * lives here, in one place, so `/p/<slug>` does not grow a chain of page-type
- * branches and so every listing keeps exactly one implementation: these are the
- * same sections the static routes render.
- *
- * Which type maps to which listing is {@link resolvePageListingLayout}'s job;
- * this only renders what that returned.
- *
- * Not to be confused with `PageListingBlock`, which is a listing *of pages*
- * placed inside rich-text content. This is the listing a page *is*.
- */
+/** The listing a page *is*, not `PageListingBlock`, which is a listing of pages. */
 import { MAX_PAGE, type SearchParams } from "@venuecms/sdk-next";
 
 import { EventsListSection } from "@/components/EventsPage";
@@ -21,24 +6,12 @@ import { NewsView } from "@/components/News";
 import { ProductsListSection } from "@/components/ShopPage";
 import type { PageListingLayout } from "@/components/utils/pageLayout";
 
-/**
- * The page a URL is asking the products listing for, or 0.
- *
- * Read inline rather than through a shared helper on purpose. VEN-514 (#69)
- * lands `readPage` with exactly these rules in `components/Pagination`, and two
- * exported readers of one param is how a route's pager and a listing block's
- * pager start answering the same URL differently. This goes when that lands.
- *
- * Digits rather than `Number()`, which reads "0x10" as 16 and "1e3" as 1000 —
- * query strings no link produces, the second quietly asking the endpoint for
- * the deepest offset scan it permits. A repeated param takes its first value,
- * as a route would read `?page=1&page=2`. Past MAX_PAGE clamps rather than
- * resetting, so the deepest reachable page still renders a link back.
- */
+// Duplicates VEN-514's readPage (#69) on purpose; drop when that lands.
 const readPage = (searchParams: SearchParams): number => {
   const raw = searchParams.page;
   const value = Array.isArray(raw) ? raw[0] : raw;
 
+  // Digits only: Number() reads "1e3" as the deepest offset scan the endpoint allows.
   if (typeof value !== "string" || !/^\d+$/.test(value)) {
     return 0;
   }
@@ -55,23 +28,9 @@ export const PageListing = ({
 }: {
   layout: PageListingLayout;
   locale: string;
-  /**
-   * The page's own title, for the listings that draw one.
-   *
-   * News and events both head their layout with a title, and a page an author
-   * titled and then typed as one of those would otherwise announce itself with
-   * whatever heading the static route reads for itself — a wrong title rather
-   * than a missing one. The shop draws no heading at all, on `/shop` or
-   * anywhere else, so there is nothing to hand it; see the products branch.
-   */
   title?: string;
-  /**
-   * The path this page lives at, for any pager the listing draws. Only the
-   * route knows it, and a listing that guessed `/shop` would page a reader
-   * clean off the page they are on.
-   */
+  /** Path any pager builds hrefs against; only the route knows it. */
   basePath: string;
-  /** The route's search params, which carry the page being read. */
   searchParams: SearchParams;
 }) => {
   switch (layout) {
@@ -79,10 +38,7 @@ export const PageListing = ({
       return <NewsView title={title} searchParams={searchParams} />;
     case "events":
       return <EventsListSection locale={locale} title={title} />;
-    // No title: this template's shop is a bare grid with no heading slot to
-    // put one in, and inventing one here would be a layout decision rather
-    // than a port. Showing what an author wrote above the products is what
-    // #66 ("'Shop' page content shows above products") is for.
+    // No title: the shop grid has no heading slot; page content above it is #66.
     case "products":
       return (
         <ProductsListSection

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -1,0 +1,95 @@
+/**
+ * The listing a page renders in place of its own content.
+ *
+ * A page marked in the CMS as the site's news / events / products index shows
+ * that index, not the page layout — which is what lets an author put the index
+ * anywhere in the tree and still have it look like `/events`. The dispatch
+ * lives here, in one place, so `/p/<slug>` does not grow a chain of page-type
+ * branches and so every listing keeps exactly one implementation: these are the
+ * same sections the static routes render.
+ *
+ * Which type maps to which listing is {@link resolvePageListingLayout}'s job;
+ * this only renders what that returned.
+ *
+ * Not to be confused with `PageListingBlock`, which is a listing *of pages*
+ * placed inside rich-text content. This is the listing a page *is*.
+ */
+import { MAX_PAGE, type SearchParams } from "@venuecms/sdk-next";
+
+import { EventsListSection } from "@/components/EventsPage";
+import { NewsView } from "@/components/News";
+import { ProductsListSection } from "@/components/ShopPage";
+import type { PageListingLayout } from "@/components/utils/pageLayout";
+
+/**
+ * The page a URL is asking the products listing for, or 0.
+ *
+ * Read inline rather than through a shared helper on purpose. VEN-514 (#69)
+ * lands `readPage` with exactly these rules in `components/Pagination`, and two
+ * exported readers of one param is how a route's pager and a listing block's
+ * pager start answering the same URL differently. This goes when that lands.
+ *
+ * Digits rather than `Number()`, which reads "0x10" as 16 and "1e3" as 1000 —
+ * query strings no link produces, the second quietly asking the endpoint for
+ * the deepest offset scan it permits. A repeated param takes its first value,
+ * as a route would read `?page=1&page=2`. Past MAX_PAGE clamps rather than
+ * resetting, so the deepest reachable page still renders a link back.
+ */
+const readPage = (searchParams: SearchParams): number => {
+  const raw = searchParams.page;
+  const value = Array.isArray(raw) ? raw[0] : raw;
+
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    return 0;
+  }
+
+  return Math.min(Number(value), MAX_PAGE);
+};
+
+export const PageListing = ({
+  layout,
+  locale,
+  title,
+  basePath,
+  searchParams,
+}: {
+  layout: PageListingLayout;
+  locale: string;
+  /**
+   * The page's own title, for the listings that draw one.
+   *
+   * News and events both head their layout with a title, and a page an author
+   * titled and then typed as one of those would otherwise announce itself with
+   * whatever heading the static route reads for itself — a wrong title rather
+   * than a missing one. The shop draws no heading at all, on `/shop` or
+   * anywhere else, so there is nothing to hand it; see the products branch.
+   */
+  title?: string;
+  /**
+   * The path this page lives at, for any pager the listing draws. Only the
+   * route knows it, and a listing that guessed `/shop` would page a reader
+   * clean off the page they are on.
+   */
+  basePath: string;
+  /** The route's search params, which carry the page being read. */
+  searchParams: SearchParams;
+}) => {
+  switch (layout) {
+    case "news":
+      return <NewsView title={title} searchParams={searchParams} />;
+    case "events":
+      return <EventsListSection locale={locale} title={title} />;
+    // No title: this template's shop is a bare grid with no heading slot to
+    // put one in, and inventing one here would be a layout decision rather
+    // than a port. Showing what an author wrote above the products is what
+    // #66 ("'Shop' page content shows above products") is for.
+    case "products":
+      return (
+        <ProductsListSection
+          locale={locale}
+          basePath={basePath}
+          currentPage={readPage(searchParams)}
+        />
+      );
+  }
+};

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -59,8 +59,10 @@ export const PageListing = ({
       );
     // Frame only, and no title: /shop draws no heading, and the records are the
     // body's own product listing block, not a second grid fetched here.
+    //
+    // Nothing to frame means no frame: a bare section is a screenful of padding.
     case "products":
-      return <ProductsLayout>{body}</ProductsLayout>;
+      return body ? <ProductsLayout>{body}</ProductsLayout> : null;
     // The events frame, which is also the archive's: with no /profiles route to
     // mirror, the index layout this template already uses is the one to match.
     case "profiles":

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -1,7 +1,6 @@
 /** The listing a page *is*, not `PageListingBlock`, which is a listing of pages. */
 import {
   type LocalizedContent,
-  MAX_PAGE,
   type SearchParams,
   VenueContent,
 } from "@venuecms/sdk-next";
@@ -13,19 +12,7 @@ import { ProfilesListSection } from "@/components/ProfilesPage";
 import { ProductsListSection } from "@/components/ShopPage";
 import { hasRenderableContent } from "@/components/utils/pageContent";
 import type { PageListingLayout } from "@/components/utils/pageLayout";
-
-// Duplicates VEN-514's readPage (#69) on purpose; drop when that lands.
-const readPage = (searchParams: SearchParams): number => {
-  const raw = searchParams.page;
-  const value = Array.isArray(raw) ? raw[0] : raw;
-
-  // Digits only: Number() reads "1e3" as the deepest offset scan the endpoint allows.
-  if (typeof value !== "string" || !/^\d+$/.test(value)) {
-    return 0;
-  }
-
-  return Math.min(Number(value), MAX_PAGE);
-};
+import { readPage } from "@/components/utils/searchParams";
 
 export const PageListing = ({
   layout,

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -9,6 +9,7 @@ import {
 import { EventsListSection } from "@/components/EventsPage";
 import { contentComponents } from "@/components/ListingBlock";
 import { NewsView } from "@/components/News";
+import { ProfilesListSection } from "@/components/ProfilesPage";
 import { ProductsListSection } from "@/components/ShopPage";
 import { hasRenderableContent } from "@/components/utils/pageContent";
 import type { PageListingLayout } from "@/components/utils/pageLayout";
@@ -76,6 +77,12 @@ export const PageListing = ({
         >
           {body}
         </ProductsListSection>
+      );
+    // The events frame, which is also the archive's: with no /profiles route to
+    // mirror, the index layout this template already uses is the one to match.
+    case "profiles":
+      return (
+        <ProfilesListSection title={title}>{body}</ProfilesListSection>
       );
   }
 };

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -10,6 +10,7 @@ import { EventsListSection } from "@/components/EventsPage";
 import { contentComponents } from "@/components/ListingBlock";
 import { NewsView } from "@/components/News";
 import { ProductsListSection } from "@/components/ShopPage";
+import { hasRenderableContent } from "@/components/utils/pageContent";
 import type { PageListingLayout } from "@/components/utils/pageLayout";
 
 // Duplicates VEN-514's readPage (#69) on purpose; drop when that lands.
@@ -36,16 +37,16 @@ export const PageListing = ({
   layout: PageListingLayout;
   locale: string;
   title?: string;
-  /** The page's own body, which is a listing's content as much as the records are. */
+  /** The page's own body, rendered above the records. */
   content?: LocalizedContent;
   /** Path any pager builds hrefs against; only the route knows it. */
   basePath: string;
   searchParams: SearchParams;
 }) => {
-  // Emptiness decided here, not in the views: a VenueContent that renders null
-  // still leaves them holding a spacer around nothing.
+  // Emptiness decided here, not in the views, which would otherwise space
+  // around a VenueContent that renders nothing.
   const body =
-    content?.content || content?.contentJSON ? (
+    content && hasRenderableContent(content) ? (
       <VenueContent
         className="flex max-w-[42rem] flex-col gap-6 text-sm"
         content={content}
@@ -55,7 +56,7 @@ export const PageListing = ({
     ) : null;
 
   switch (layout) {
-    // No body: the news layout already renders an article's content in full.
+    // No body: this layout renders the latest article's, and two would compete.
     case "news":
       return <NewsView title={title} searchParams={searchParams} />;
     case "events":
@@ -71,6 +72,7 @@ export const PageListing = ({
           locale={locale}
           basePath={basePath}
           currentPage={readPage(searchParams)}
+          searchParams={searchParams}
         >
           {body}
         </ProductsListSection>

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -81,7 +81,16 @@ export const PageListing = ({
     // The events frame, which is also the archive's: with no /profiles route to
     // mirror, the index layout this template already uses is the one to match.
     case "profiles":
-      return <ProfilesListSection title={title}>{body}</ProfilesListSection>;
+      return (
+        <ProfilesListSection
+          title={title}
+          basePath={basePath}
+          currentPage={readPage(searchParams)}
+          searchParams={searchParams}
+        >
+          {body}
+        </ProfilesListSection>
+      );
   }
 
   // A layout added to the union without a case above is a compile error here

--- a/src/components/PageListing/index.tsx
+++ b/src/components/PageListing/index.tsx
@@ -1,7 +1,13 @@
 /** The listing a page *is*, not `PageListingBlock`, which is a listing of pages. */
-import { MAX_PAGE, type SearchParams } from "@venuecms/sdk-next";
+import {
+  type LocalizedContent,
+  MAX_PAGE,
+  type SearchParams,
+  VenueContent,
+} from "@venuecms/sdk-next";
 
 import { EventsListSection } from "@/components/EventsPage";
+import { contentComponents } from "@/components/ListingBlock";
 import { NewsView } from "@/components/News";
 import { ProductsListSection } from "@/components/ShopPage";
 import type { PageListingLayout } from "@/components/utils/pageLayout";
@@ -23,29 +29,51 @@ export const PageListing = ({
   layout,
   locale,
   title,
+  content,
   basePath,
   searchParams,
 }: {
   layout: PageListingLayout;
   locale: string;
   title?: string;
+  /** The page's own body, which is a listing's content as much as the records are. */
+  content?: LocalizedContent;
   /** Path any pager builds hrefs against; only the route knows it. */
   basePath: string;
   searchParams: SearchParams;
 }) => {
+  // Emptiness decided here, not in the views: a VenueContent that renders null
+  // still leaves them holding a spacer around nothing.
+  const body =
+    content?.content || content?.contentJSON ? (
+      <VenueContent
+        className="flex max-w-[42rem] flex-col gap-6 text-sm"
+        content={content}
+        contentStyles={contentComponents}
+        searchParams={searchParams}
+      />
+    ) : null;
+
   switch (layout) {
+    // No body: the news layout already renders an article's content in full.
     case "news":
       return <NewsView title={title} searchParams={searchParams} />;
     case "events":
-      return <EventsListSection locale={locale} title={title} />;
-    // No title: the shop grid has no heading slot; page content above it is #66.
+      return (
+        <EventsListSection locale={locale} title={title}>
+          {body}
+        </EventsListSection>
+      );
+    // No title: the shop grid has no heading slot.
     case "products":
       return (
         <ProductsListSection
           locale={locale}
           basePath={basePath}
           currentPage={readPage(searchParams)}
-        />
+        >
+          {body}
+        </ProductsListSection>
       );
   }
 };

--- a/src/components/Pagination/index.test.tsx
+++ b/src/components/Pagination/index.test.tsx
@@ -75,6 +75,21 @@ describe("Pagination", () => {
     expect(html).not.toContain("page=6");
   });
 
+  // A listing block in the same page's body pages by a param of its own.
+  it("carries the rest of the query string across a page move", async () => {
+    const html = await render(
+      <Pagination
+        currentPage={1}
+        totalPages={5}
+        baseUrl="/p/merch"
+        searchParams={{ page: "1", evt_9k3z1: "3" }}
+      />,
+    );
+
+    expect(html).toContain("/p/merch?evt_9k3z1=3&amp;page=0");
+    expect(html).toContain("/p/merch?evt_9k3z1=3&amp;page=2");
+  });
+
   it("renders nothing when there are no pages to move between", async () => {
     await expect(
       render(<Pagination currentPage={0} totalPages={0} baseUrl="/archive" />),

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,8 +1,11 @@
+import type { SearchParams } from "@venuecms/sdk-next";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { ReactNode } from "react";
 
 import { Link } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
+
+import { buildPageHref } from "@/components/utils/searchParams";
 
 /**
  * The prev/next control itself: two arrows and nothing else.
@@ -87,6 +90,8 @@ interface PaginationProps {
   currentPage: number;
   totalPages: number;
   baseUrl: string;
+  /** Carried through, so paging the page does not reset a listing block in its body. */
+  searchParams?: SearchParams;
   className?: string;
 }
 
@@ -94,13 +99,14 @@ export const Pagination = ({
   currentPage,
   totalPages,
   baseUrl,
+  searchParams = {},
   className,
 }: PaginationProps) => {
   if (totalPages < 1) {
     return null; // Don't render pagination if there's only one page or less
   }
 
-  const pageHref = (page: number) => `${baseUrl}?page=${page}`;
+  const pageHref = (page: number) => buildPageHref(baseUrl, searchParams, page);
 
   return (
     <PaginationLinks

--- a/src/components/Pagination/scroll.test.tsx
+++ b/src/components/Pagination/scroll.test.tsx
@@ -18,7 +18,7 @@ import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
-import { PaginatedListing } from "@/components/ListingBlock/ListingPager";
+import { PaginatedListing } from "@/components/ListingBlock/ListingRoot";
 
 import { PaginationLinks } from "./index";
 

--- a/src/components/ProfileList/index.test.tsx
+++ b/src/components/ProfileList/index.test.tsx
@@ -1,0 +1,55 @@
+import type { ListingRecords } from "@venuecms/sdk-next";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ProfileListingBlock } from "@/components/ListingBlock/blocks";
+
+import { ProfilesList } from "./index";
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(
+    <NextIntlClientProvider locale="en" messages={{}}>
+      {node}
+    </NextIntlClientProvider>,
+  );
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+const profiles = (...titles: string[]): ListingRecords["profileListing"] =>
+  titles.map((title, index) => ({
+    siteId: "site-id",
+    slug: `profile-${index}`,
+    localizedContent: [{ siteId: "site-id", locale: "en", title }],
+  }));
+
+describe("ProfilesList", () => {
+  it("draws a card per profile", async () => {
+    const html = await render(
+      <ProfilesList profiles={profiles("An artist", "Another artist")} />,
+    );
+
+    expect(html).toContain("An artist");
+    expect(html).toContain("Another artist");
+    expect(html).toContain("/artists/profile-0");
+  });
+
+  it("renders nothing but the grid for no profiles", async () => {
+    expect(await render(<ProfilesList profiles={[]} />)).not.toContain("<a");
+  });
+
+  // Asserted against the shared list rather than its class names: the point of
+  // extracting it is that the profile listing page and the content block cannot
+  // drift, and comparing markup is what catches one of them growing a wrapper.
+  it("is what the profile listing block draws", async () => {
+    const records = profiles("An artist", "Another artist");
+
+    expect(
+      await render(
+        <ProfileListingBlock records={records} site={null} pagination={null} />,
+      ),
+    ).toBe(await render(<ProfilesList profiles={records} className="py-4" />));
+  });
+});

--- a/src/components/ProfileList/index.test.tsx
+++ b/src/components/ProfileList/index.test.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import { ListingRoot } from "@/components/ListingBlock/ListingRoot";
 import { ProfileListingBlock } from "@/components/ListingBlock/blocks";
 
 import { ProfilesList } from "./index";
@@ -43,6 +44,11 @@ describe("ProfilesList", () => {
   // Asserted against the shared list rather than its class names: the point of
   // extracting it is that the profile listing page and the content block cannot
   // drift, and comparing markup is what catches one of them growing a wrapper.
+  //
+  // The block draws its list inside `ListingRoot` — the element that carries
+  // `data-listing`, and so the one a page body exempts from the prose measure —
+  // which is why that is spelled out on the right rather than dropped from the
+  // comparison.
   it("is what the profile listing block draws", async () => {
     const records = profiles("An artist", "Another artist");
 
@@ -50,6 +56,12 @@ describe("ProfilesList", () => {
       await render(
         <ProfileListingBlock records={records} site={null} pagination={null} />,
       ),
-    ).toBe(await render(<ProfilesList profiles={records} className="py-4" />));
+    ).toBe(
+      await render(
+        <ListingRoot>
+          <ProfilesList profiles={records} className="py-4" />
+        </ListingRoot>,
+      ),
+    );
   });
 });

--- a/src/components/ProfileList/index.tsx
+++ b/src/components/ProfileList/index.tsx
@@ -1,0 +1,26 @@
+import type { Profile } from "@venuecms/sdk-next";
+
+import { ProfileCompact } from "@/components/ProfileCompact";
+import { TwoSubColumnLayout } from "@/components/layout";
+
+/**
+ * The grid of profile cards, shared by the profile listing page and the profile
+ * listing block, so a page typed `PROFILELIST` and a `profileListing` block in
+ * someone's prose cannot end up drawing the same records two different ways.
+ *
+ * The sibling of `EventsList` for events; a plain function of the records it is
+ * handed, and the one list that needs no `site` to draw.
+ */
+export const ProfilesList = ({
+  profiles,
+  className,
+}: {
+  profiles: readonly Profile[];
+  className?: string;
+}) => (
+  <TwoSubColumnLayout className={className}>
+    {profiles.map((profile) => (
+      <ProfileCompact key={profile.slug} profile={profile} />
+    ))}
+  </TwoSubColumnLayout>
+);

--- a/src/components/ProfileList/index.tsx
+++ b/src/components/ProfileList/index.tsx
@@ -4,9 +4,14 @@ import { ProfileCompact } from "@/components/ProfileCompact";
 import { TwoSubColumnLayout } from "@/components/layout";
 
 /**
- * The grid of profile cards, shared by the profile listing page and the profile
- * listing block, so a page typed `PROFILELIST` and a `profileListing` block in
- * someone's prose cannot end up drawing the same records two different ways.
+ * The grid of profile cards, shared by the profile listing page and the
+ * `profileListing` content block so those two cannot draw the same records two
+ * different ways.
+ *
+ * Not yet shared by the three grids that render a *record's* attached artists —
+ * `Page`, `Event` and `Product` each still inline this markup. They are the
+ * same grid and should move here, but that is a change to pages this branch
+ * does not otherwise touch, and one no test here would catch regressing.
  *
  * The sibling of `EventsList` for events; a plain function of the records it is
  * handed, and the one list that needs no `site` to draw.

--- a/src/components/ProfilesPage/ProfilesListContent.test.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.test.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ProfilesListContent } from "./ProfilesListContent";
+import { PROFILES_PER_PAGE, ProfilesListContent } from "./ProfilesListContent";
 import { ProfilesListSection } from "./ProfilesListSection";
 
 vi.mock("next/server", () => ({ connection: async () => {} }));
@@ -38,6 +38,17 @@ const aProfile = (title: string) => ({
   slug: title.toLowerCase().replace(/\s+/g, "-"),
   localizedContent: [{ siteId: "site-id", locale: "en", title }],
 });
+
+/** A page of the roster `n` records long, to page off the end of. */
+const aRoster = (n: number) =>
+  Array.from({ length: n }, (_, i) => aProfile(`Artist ${i}`));
+
+const renderRoster = (
+  props: Partial<Parameters<typeof ProfilesListSection>[0]> = {},
+) =>
+  render(
+    <ProfilesListSection basePath="/p/roster" currentPage={0} {...props} />,
+  );
 
 let profileRecords: Array<Record<string, unknown>> = [];
 let profilesReadFails = false;
@@ -81,16 +92,14 @@ describe("the profiles listing", () => {
   it("draws the profiles the endpoint returned", async () => {
     profileRecords = [aProfile("An Artist")];
 
-    const html = await render(<ProfilesListSection title="Artists" />);
+    const html = await renderRoster({ title: "Artists" });
 
     expect(html).toContain("An Artist");
     expect(html).toContain("/artists/an-artist");
   });
 
   it("heads itself with the listing page's own title", async () => {
-    expect(await render(<ProfilesListSection title="Roster" />)).toContain(
-      "Roster",
-    );
+    expect(await renderRoster({ title: "Roster" })).toContain("Roster");
   });
 
   // Unlike events and shop, this template has no /profiles route and so no page
@@ -102,14 +111,14 @@ describe("the profiles listing", () => {
     ["an empty title", ""],
     ["a whitespace-only title", "   "],
   ])("falls back to a heading of its own given %s", async (_label, title) => {
-    const html = await render(<ProfilesListSection title={title} />);
+    const html = await renderRoster({ title });
 
     expect(html).toContain("artists");
     expect(requestedUrls().some((url) => url.includes("/pages"))).toBe(false);
   });
 
   it("says so when there are no profiles", async () => {
-    expect(await render(<ProfilesListSection title="Artists" />)).toContain(
+    expect(await renderRoster({ title: "Artists" })).toContain(
       "No artists found",
     );
   });
@@ -122,15 +131,15 @@ describe("the profiles listing", () => {
   it("fails loudly rather than reporting an outage as an empty roster", async () => {
     profilesReadFails = true;
 
-    await expect(ProfilesListContent()).rejects.toThrow(
-      "The profiles endpoint could not be read.",
-    );
+    await expect(
+      ProfilesListContent({ basePath: "/p/roster", currentPage: 0 }),
+    ).rejects.toThrow("The profiles endpoint could not be read.");
   });
 
   // A profile card needs no site, so asking for one would only add a request
   // that a failed read could then 404 the whole page on.
   it("reads no site", async () => {
-    await render(<ProfilesListSection title="Artists" />);
+    await renderRoster({ title: "Artists" });
 
     expect(requestedUrls().every((url) => url.includes("/profiles"))).toBe(
       true,
@@ -141,7 +150,7 @@ describe("the profiles listing", () => {
   // Sending one here would order the same roster differently on the two
   // surfaces the shared `ProfilesList` exists to keep identical.
   it("orders the roster the way a content block does", async () => {
-    await render(<ProfilesListSection title="Artists" />);
+    await renderRoster({ title: "Artists" });
 
     const query = new URL(requestedUrls()[0]).searchParams;
 
@@ -153,11 +162,10 @@ describe("the profiles listing", () => {
     profileRecords = [aProfile("An Artist")];
 
     const column = columnRight(
-      await render(
-        <ProfilesListSection title="Artists">
-          <p>Roster notes</p>
-        </ProfilesListSection>,
-      ),
+      await renderRoster({
+        title: "Artists",
+        children: <p>Roster notes</p>,
+      }),
     );
 
     expect(column.indexOf("Roster notes")).toBeGreaterThan(-1);
@@ -172,15 +180,93 @@ describe("the profiles listing", () => {
   it("keeps the title and the body when the roster fails", async () => {
     profilesReadFails = true;
 
-    const html = await render(
-      <ProfilesListSection title="Artists">
-        <p>Roster notes</p>
-      </ProfilesListSection>,
-    );
+    const html = await renderRoster({
+      title: "Artists",
+      children: <p>Roster notes</p>,
+    });
 
     expect(html).toContain("Artists");
     expect(html).toContain("Roster notes");
     // And does not pass the failure off as a roster that is merely empty.
     expect(html).not.toContain("No artists found");
+  });
+});
+
+/**
+ * The roster pages like /archive and /shop: a shared `?page=`, hrefs against
+ * the page's own path, and the reader taken to the top of the new page.
+ *
+ * What it cannot borrow from them is their arithmetic. `count` is optional on
+ * the profiles response, so there is no total to divide into pages, and the
+ * only end-of-roster signal available is a page that came back short. That is
+ * the same rule the SDK applies to a `profileListing` block, which is what
+ * keeps the two surfaces agreeing about where the roster ends.
+ */
+describe("the profile roster's pager", () => {
+  it("asks the endpoint for the page it was given", async () => {
+    profileRecords = aRoster(PROFILES_PER_PAGE);
+
+    await renderRoster({ currentPage: 2 });
+
+    expect(new URL(requestedUrls()[0]).searchParams.get("page")).toBe("2");
+  });
+
+  it("links on to the next page while pages come back full", async () => {
+    profileRecords = aRoster(PROFILES_PER_PAGE);
+
+    expect(await renderRoster()).toContain("/p/roster?page=1");
+  });
+
+  // The short page is the end of the roster; offering a next link here walks
+  // the reader onto a page that is empty by construction.
+  it("offers no next page from a short one", async () => {
+    profileRecords = aRoster(PROFILES_PER_PAGE - 1);
+
+    expect(await renderRoster()).not.toContain("page=1");
+  });
+
+  it("offers no previous page from the first", async () => {
+    profileRecords = aRoster(PROFILES_PER_PAGE);
+
+    expect(await renderRoster()).not.toContain("Previous page");
+  });
+
+  // A roster whose length is an exact multiple of the page size hands out a
+  // next link to an empty page. Dropping the pager there would strand a reader
+  // who followed it with no way back.
+  it("keeps a way back off an empty page", async () => {
+    profileRecords = [];
+
+    expect(await renderRoster({ currentPage: 2 })).toContain(
+      "/p/roster?page=1",
+    );
+  });
+
+  // Paging the roster must not reset a listing block sitting in the page's
+  // own body, which pages by a param of its own.
+  it("carries the page's other params through", async () => {
+    profileRecords = aRoster(PROFILES_PER_PAGE);
+
+    const html = await renderRoster({
+      searchParams: { page: "0", prf_9k3z1: "3" },
+    });
+
+    expect(html).toContain("prf_9k3z1=3");
+  });
+
+  // A PROFILELIST page can carry several pagers — every listing block in its
+  // body brings one — so the roster's landmark needs a name of its own.
+  it("names its own nav", async () => {
+    profileRecords = aRoster(PROFILES_PER_PAGE);
+
+    expect(await renderRoster()).toContain('aria-label="Artists pagination"');
+  });
+
+  // Nothing to page is nothing to draw: a single-page roster gets no nav of
+  // two dead arrows.
+  it("draws no pager for a roster that fits on one page", async () => {
+    profileRecords = aRoster(3);
+
+    expect(await renderRoster()).not.toContain("Artists pagination");
   });
 });

--- a/src/components/ProfilesPage/ProfilesListContent.test.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.test.tsx
@@ -1,0 +1,132 @@
+import { setConfig } from "@venuecms/sdk-next";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProfilesListContent } from "./ProfilesListContent";
+import { ProfilesListSection } from "./ProfilesListSection";
+
+vi.mock("next/server", () => ({ connection: async () => {} }));
+
+// ColumnLeft is emitted first, so a body moved into it still reads as "before
+// the profiles" unless the assertion names the column that should hold it.
+const columnRight = (html: string) => html.split('class="col-span-2')[1] ?? "";
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(
+    <NextIntlClientProvider locale="en" messages={{}}>
+      {node}
+    </NextIntlClientProvider>,
+  );
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+const requestedUrls = () =>
+  vi
+    .mocked(globalThis.fetch)
+    .mock.calls.map(([input]) =>
+      input instanceof Request ? input.url : String(input),
+    );
+
+let profileRecords: Array<Record<string, unknown>> = [];
+
+beforeEach(() => {
+  setConfig({ siteKey: "test-site" });
+  profileRecords = [];
+
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = input instanceof Request ? input.url : String(input);
+
+    const body = url.includes("/profiles")
+      ? { records: profileRecords, count: profileRecords.length }
+      : { id: "site-id", timeZone: "Europe/Berlin", settings: {} };
+
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const aProfile = (title: string) => ({
+  siteId: "site-id",
+  slug: title.toLowerCase().replace(/\s+/g, "-"),
+  localizedContent: [{ siteId: "site-id", locale: "en", title }],
+});
+
+describe("the profiles listing", () => {
+  it("draws the profiles the endpoint returned", async () => {
+    profileRecords = [aProfile("An Artist")];
+
+    const html = await render(<ProfilesListContent title="Artists" />);
+
+    expect(html).toContain("An Artist");
+    expect(html).toContain("/artists/an-artist");
+  });
+
+  it("heads itself with the listing page's own title", async () => {
+    expect(await render(<ProfilesListContent title="Roster" />)).toContain(
+      "Roster",
+    );
+  });
+
+  // Unlike events and shop, this template has no /profiles route and so no page
+  // record to fall back to, which is why the heading is only ever the page's.
+  it("falls back to a heading of its own without one", async () => {
+    const html = await render(<ProfilesListContent />);
+
+    expect(html).toContain("artists");
+    expect(requestedUrls().some((url) => url.includes("/pages"))).toBe(false);
+  });
+
+  it("says so when there are no profiles", async () => {
+    expect(await render(<ProfilesListContent title="Artists" />)).toContain(
+      "No artists found",
+    );
+  });
+
+  // A profile card needs no site, so asking for one would only add a request
+  // that a failed read could then 404 the whole page on.
+  it("reads no site", async () => {
+    await render(<ProfilesListContent title="Artists" />);
+
+    expect(requestedUrls().every((url) => url.includes("/profiles"))).toBe(true);
+  });
+
+  it("renders a body it was handed above the profiles", async () => {
+    profileRecords = [aProfile("An Artist")];
+
+    const column = columnRight(
+      await render(
+        <ProfilesListContent title="Artists">
+          <p>Roster notes</p>
+        </ProfilesListContent>,
+      ),
+    );
+
+    expect(column.indexOf("Roster notes")).toBeGreaterThan(-1);
+    expect(column.indexOf("Roster notes")).toBeLessThan(
+      column.indexOf("An Artist"),
+    );
+  });
+});
+
+describe("the profiles listing section", () => {
+  it("hands the body it was given to the content it wraps", async () => {
+    const column = columnRight(
+      await render(
+        <ProfilesListSection title="Artists">
+          <p>Roster notes</p>
+        </ProfilesListSection>,
+      ),
+    );
+
+    expect(column).toContain("Roster notes");
+  });
+});

--- a/src/components/ProfilesPage/ProfilesListContent.test.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.test.tsx
@@ -52,11 +52,14 @@ const renderRoster = (
 
 let profileRecords: Array<Record<string, unknown>> = [];
 let profilesReadFails = false;
+/** The roster's total, or null for the endpoint answering without one. */
+let profilesCount: number | null = null;
 
 beforeEach(() => {
   setConfig({ siteKey: "test-site" });
   profileRecords = [];
   profilesReadFails = false;
+  profilesCount = null;
 
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = input instanceof Request ? input.url : String(input);
@@ -67,7 +70,9 @@ beforeEach(() => {
         : new Response(
             JSON.stringify({
               records: profileRecords,
-              count: profileRecords.length,
+              // Omitted, not nulled, when there is none: `count` is optional on
+              // this response and a real endpoint leaves the key off entirely.
+              ...(profilesCount === null ? {} : { count: profilesCount }),
             }),
             { status: 200, headers: { "content-type": "application/json" } },
           );
@@ -196,11 +201,9 @@ describe("the profiles listing", () => {
  * The roster pages like /archive and /shop: a shared `?page=`, hrefs against
  * the page's own path, and the reader taken to the top of the new page.
  *
- * What it cannot borrow from them is their arithmetic. `count` is optional on
- * the profiles response, so there is no total to divide into pages, and the
- * only end-of-roster signal available is a page that came back short. That is
- * the same rule the SDK applies to a `profileListing` block, which is what
- * keeps the two surfaces agreeing about where the roster ends.
+ * What it cannot borrow from them is a single piece of arithmetic. `count` is
+ * optional on the profiles response, so the end of the roster is found one of
+ * two ways depending on whether the endpoint volunteered a total.
  */
 describe("the profile roster's pager", () => {
   it("asks the endpoint for the page it was given", async () => {
@@ -211,29 +214,15 @@ describe("the profile roster's pager", () => {
     expect(new URL(requestedUrls()[0]).searchParams.get("page")).toBe("2");
   });
 
-  it("links on to the next page while pages come back full", async () => {
-    profileRecords = aRoster(PROFILES_PER_PAGE);
-
-    expect(await renderRoster()).toContain("/p/roster?page=1");
-  });
-
-  // The short page is the end of the roster; offering a next link here walks
-  // the reader onto a page that is empty by construction.
-  it("offers no next page from a short one", async () => {
-    profileRecords = aRoster(PROFILES_PER_PAGE - 1);
-
-    expect(await renderRoster()).not.toContain("page=1");
-  });
-
   it("offers no previous page from the first", async () => {
     profileRecords = aRoster(PROFILES_PER_PAGE);
+    profilesCount = PROFILES_PER_PAGE * 3;
 
     expect(await renderRoster()).not.toContain("Previous page");
   });
 
-  // A roster whose length is an exact multiple of the page size hands out a
-  // next link to an empty page. Dropping the pager there would strand a reader
-  // who followed it with no way back.
+  // A reader who overshoots the roster — by following the countless case's
+  // speculative next link, or by hand-editing the URL — must not be stranded.
   it("keeps a way back off an empty page", async () => {
     profileRecords = [];
 
@@ -266,7 +255,54 @@ describe("the profile roster's pager", () => {
   // two dead arrows.
   it("draws no pager for a roster that fits on one page", async () => {
     profileRecords = aRoster(3);
+    profilesCount = 3;
 
     expect(await renderRoster()).not.toContain("Artists pagination");
+  });
+
+  // Given a total, the records already behind the reader plus the ones on this
+  // page settle exactly where the roster ends.
+  describe("given a count", () => {
+    it("links on while records remain beyond this page", async () => {
+      profileRecords = aRoster(PROFILES_PER_PAGE);
+      profilesCount = PROFILES_PER_PAGE + 1;
+
+      expect(await renderRoster()).toContain("/p/roster?page=1");
+    });
+
+    // The bug a full page alone cannot see: 50 of 50 is the end of the roster,
+    // not the middle of it.
+    it("offers no next page from a full last one", async () => {
+      profileRecords = aRoster(PROFILES_PER_PAGE);
+      profilesCount = PROFILES_PER_PAGE;
+
+      expect(await renderRoster()).not.toContain("page=1");
+    });
+
+    it("offers no next page from the last of several", async () => {
+      profileRecords = aRoster(PROFILES_PER_PAGE);
+      profilesCount = PROFILES_PER_PAGE * 2;
+
+      expect(await renderRoster({ currentPage: 1 })).not.toContain("page=2");
+    });
+  });
+
+  // Without one, a page that came back full is the only evidence another may
+  // follow — the same rule the SDK pages a `profileListing` block by, which is
+  // what keeps the two surfaces agreeing about where the roster ends.
+  describe("given no count", () => {
+    it("links on while pages come back full", async () => {
+      profileRecords = aRoster(PROFILES_PER_PAGE);
+
+      expect(await renderRoster()).toContain("/p/roster?page=1");
+    });
+
+    // The short page is the end of the roster; a next link here walks the
+    // reader onto a page that is empty by construction.
+    it("offers no next page from a short one", async () => {
+      profileRecords = aRoster(PROFILES_PER_PAGE - 1);
+
+      expect(await renderRoster()).not.toContain("page=1");
+    });
   });
 });

--- a/src/components/ProfilesPage/ProfilesListContent.test.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.test.tsx
@@ -18,6 +18,9 @@ const render = async (node: ReactNode) => {
     <NextIntlClientProvider locale="en" messages={{}}>
       {node}
     </NextIntlClientProvider>,
+    // The roster's boundary is expected to catch a failed read; without this
+    // the recoverable error still reaches the console and reads as a test error.
+    { onError: () => {} },
   );
   await stream.allReady;
   return new Response(stream).text();
@@ -30,23 +33,43 @@ const requestedUrls = () =>
       input instanceof Request ? input.url : String(input),
     );
 
+const aProfile = (title: string) => ({
+  siteId: "site-id",
+  slug: title.toLowerCase().replace(/\s+/g, "-"),
+  localizedContent: [{ siteId: "site-id", locale: "en", title }],
+});
+
 let profileRecords: Array<Record<string, unknown>> = [];
+let profilesReadFails = false;
 
 beforeEach(() => {
   setConfig({ siteKey: "test-site" });
   profileRecords = [];
+  profilesReadFails = false;
 
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = input instanceof Request ? input.url : String(input);
 
-    const body = url.includes("/profiles")
-      ? { records: profileRecords, count: profileRecords.length }
-      : { id: "site-id", timeZone: "Europe/Berlin", settings: {} };
+    if (url.includes("/profiles")) {
+      return profilesReadFails
+        ? new Response("upstream is down", { status: 500 })
+        : new Response(
+            JSON.stringify({
+              records: profileRecords,
+              count: profileRecords.length,
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+    }
 
-    return new Response(JSON.stringify(body), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
+    return new Response(
+      JSON.stringify({
+        id: "site-id",
+        timeZone: "Europe/Berlin",
+        settings: {},
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
   });
 });
 
@@ -54,71 +77,81 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-const aProfile = (title: string) => ({
-  siteId: "site-id",
-  slug: title.toLowerCase().replace(/\s+/g, "-"),
-  localizedContent: [{ siteId: "site-id", locale: "en", title }],
-});
-
 describe("the profiles listing", () => {
   it("draws the profiles the endpoint returned", async () => {
     profileRecords = [aProfile("An Artist")];
 
-    const html = await render(<ProfilesListContent title="Artists" />);
+    const html = await render(<ProfilesListSection title="Artists" />);
 
     expect(html).toContain("An Artist");
     expect(html).toContain("/artists/an-artist");
   });
 
   it("heads itself with the listing page's own title", async () => {
-    expect(await render(<ProfilesListContent title="Roster" />)).toContain(
+    expect(await render(<ProfilesListSection title="Roster" />)).toContain(
       "Roster",
     );
   });
 
   // Unlike events and shop, this template has no /profiles route and so no page
   // record to fall back to, which is why the heading is only ever the page's.
-  it("falls back to a heading of its own without one", async () => {
-    const html = await render(<ProfilesListContent />);
+  // A locale saved without a title yields "", not undefined, so the fallback
+  // has to read emptiness rather than absence or the heading column draws blank.
+  it.each([
+    ["no title", undefined],
+    ["an empty title", ""],
+    ["a whitespace-only title", "   "],
+  ])("falls back to a heading of its own given %s", async (_label, title) => {
+    const html = await render(<ProfilesListSection title={title} />);
 
     expect(html).toContain("artists");
     expect(requestedUrls().some((url) => url.includes("/pages"))).toBe(false);
   });
 
   it("says so when there are no profiles", async () => {
-    expect(await render(<ProfilesListContent title="Artists" />)).toContain(
+    expect(await render(<ProfilesListSection title="Artists" />)).toContain(
       "No artists found",
+    );
+  });
+
+  // An outage rendered as an empty roster is a cached 200 claiming the site has
+  // no artists, which is why the read has to fail loudly rather than fall
+  // through to the empty state. Asserted on the throw rather than on rendered
+  // markup: the boundary that catches it is a client component, and React hands
+  // a suspended boundary's error to the client rather than running it in SSR.
+  it("fails loudly rather than reporting an outage as an empty roster", async () => {
+    profilesReadFails = true;
+
+    await expect(ProfilesListContent()).rejects.toThrow(
+      "The profiles endpoint could not be read.",
     );
   });
 
   // A profile card needs no site, so asking for one would only add a request
   // that a failed read could then 404 the whole page on.
   it("reads no site", async () => {
-    await render(<ProfilesListContent title="Artists" />);
+    await render(<ProfilesListSection title="Artists" />);
 
-    expect(requestedUrls().every((url) => url.includes("/profiles"))).toBe(true);
+    expect(requestedUrls().every((url) => url.includes("/profiles"))).toBe(
+      true,
+    );
+  });
+
+  // A `profileListing` block sends no ordering unless its author picks one.
+  // Sending one here would order the same roster differently on the two
+  // surfaces the shared `ProfilesList` exists to keep identical.
+  it("orders the roster the way a content block does", async () => {
+    await render(<ProfilesListSection title="Artists" />);
+
+    const query = new URL(requestedUrls()[0]).searchParams;
+
+    expect(query.get("dir")).toBeNull();
+    expect(query.get("orderBy")).toBeNull();
   });
 
   it("renders a body it was handed above the profiles", async () => {
     profileRecords = [aProfile("An Artist")];
 
-    const column = columnRight(
-      await render(
-        <ProfilesListContent title="Artists">
-          <p>Roster notes</p>
-        </ProfilesListContent>,
-      ),
-    );
-
-    expect(column.indexOf("Roster notes")).toBeGreaterThan(-1);
-    expect(column.indexOf("Roster notes")).toBeLessThan(
-      column.indexOf("An Artist"),
-    );
-  });
-});
-
-describe("the profiles listing section", () => {
-  it("hands the body it was given to the content it wraps", async () => {
     const column = columnRight(
       await render(
         <ProfilesListSection title="Artists">
@@ -127,6 +160,27 @@ describe("the profiles listing section", () => {
       ),
     );
 
-    expect(column).toContain("Roster notes");
+    expect(column.indexOf("Roster notes")).toBeGreaterThan(-1);
+    expect(column.indexOf("Roster notes")).toBeLessThan(
+      column.indexOf("An Artist"),
+    );
+  });
+
+  // The heading and the body cost no request of their own, so they sit outside
+  // the boundaries: a roster failure has no business taking an author's prose
+  // or the page's title down with it.
+  it("keeps the title and the body when the roster fails", async () => {
+    profilesReadFails = true;
+
+    const html = await render(
+      <ProfilesListSection title="Artists">
+        <p>Roster notes</p>
+      </ProfilesListSection>,
+    );
+
+    expect(html).toContain("Artists");
+    expect(html).toContain("Roster notes");
+    // And does not pass the failure off as a roster that is merely empty.
+    expect(html).not.toContain("No artists found");
   });
 });

--- a/src/components/ProfilesPage/ProfilesListContent.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.tsx
@@ -1,49 +1,39 @@
 import { getProfiles } from "@venuecms/sdk-next";
 import { connection } from "next/server";
-import type { ReactNode } from "react";
 
 import { ProfilesList } from "@/components/ProfileList";
-import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
 
-// One page of profiles, matching the roster template-liminal lists. The
-// endpoint pages, but no route here does: profiles are a cast list, not a feed,
-// and `count` is optional on that response, so a pager could not size itself.
+// One page of profiles, matching the roster template-liminal lists and the cap
+// /events already puts on its own index. Records past it are not reachable from
+// this page; giving it a pager is a follow-up, not a silent detail.
 const PROFILE_LIMIT = 99;
 
-export async function ProfilesListContent({
-  title,
-  children,
-}: {
-  /**
-   * Heading. Always the listing page's own: unlike events and shop, this
-   * template has no /profiles route and so no page record to read one from.
-   */
-  title?: string;
-  children?: ReactNode;
-}) {
+/**
+ * The records half of the profile listing. Draws only the grid: its frame, its
+ * heading and the page's own body live in `ProfilesListSection`, above the
+ * Suspense boundary, so none of them wait on this fetch or vanish with it.
+ */
+export async function ProfilesListContent() {
   await connection();
 
-  const { data: profiles } = await getProfiles({
-    limit: PROFILE_LIMIT,
-    dir: "desc",
-  });
+  // No `dir`/`orderBy`: a `profileListing` block sends neither unless its author
+  // picks one, so leaving them off is what makes this page and that block order
+  // the same roster the same way.
+  const { data: profiles } = await getProfiles({ limit: PROFILE_LIMIT });
+
+  // The SDK reports a failed read as absent data rather than throwing, which
+  // would otherwise render an outage as an empty roster — a cached 200 saying
+  // the site has no artists. Throwing hands it to the error boundary instead.
+  if (!profiles) {
+    throw new Error("The profiles endpoint could not be read.");
+  }
 
   // No site read, and so no `notFound` on a failed one: a profile card draws
   // from the profile alone, and asking would only add a request that could
   // take the page down with it.
-  return (
-    <TwoColumnLayout>
-      <ColumnLeft className="text-sm text-secondary">
-        <p className="pb-8 text-primary">{title ?? "artists"}</p>
-      </ColumnLeft>
-      <ColumnRight>
-        {children}
-        {profiles?.records.length ? (
-          <ProfilesList profiles={profiles.records} />
-        ) : (
-          "No artists found"
-        )}
-      </ColumnRight>
-    </TwoColumnLayout>
+  return profiles.records.length ? (
+    <ProfilesList profiles={profiles.records} />
+  ) : (
+    "No artists found"
   );
 }

--- a/src/components/ProfilesPage/ProfilesListContent.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.tsx
@@ -40,23 +40,32 @@ export async function ProfilesListContent({
     throw new Error("The profiles endpoint could not be read.");
   }
 
-  const { records } = profiles;
+  const { records, count } = profiles;
 
-  // `count` is optional on the profiles response, so unlike /shop there is no
-  // total to divide into pages: a page that came back full is the only evidence
-  // another may follow. The SDK pages a `profileListing` block by that same
-  // rule, which is what keeps the two surfaces agreeing where the roster ends.
+  // `count` is optional on the profiles response, so the roster's end is found
+  // two ways. Given a count, the records already behind the reader plus the
+  // ones on this page settle it exactly. Without one, a page that came back
+  // full is the only evidence another may follow — the rule the SDK pages a
+  // `profileListing` block by, which is what keeps the two surfaces agreeing
+  // about where the roster ends.
   //
-  // It does mean a roster whose length is an exact multiple of the page size
-  // offers one link to an empty page. That page keeps its pager rather than
-  // stranding whoever followed it.
+  // The countless case does mean a roster whose length is an exact multiple of
+  // the page size offers one link to an empty page. That page keeps its pager
+  // rather than stranding whoever followed it.
+  const hasNextPage =
+    typeof count === "number"
+      ? (currentPage + 1) * PROFILES_PER_PAGE < count
+      : records.length === PROFILES_PER_PAGE;
+
   const prevHref =
     currentPage > 0
       ? buildPageHref(basePath, searchParams, currentPage - 1)
       : null;
 
+  // Clamped at the deepest offset the endpoint will scan, so a pager cannot
+  // walk a reader past the page the SDK would refuse anyway.
   const nextHref =
-    records.length === PROFILES_PER_PAGE && currentPage < MAX_PAGE
+    hasNextPage && currentPage < MAX_PAGE
       ? buildPageHref(basePath, searchParams, currentPage + 1)
       : null;
 

--- a/src/components/ProfilesPage/ProfilesListContent.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.tsx
@@ -1,25 +1,37 @@
-import { getProfiles } from "@venuecms/sdk-next";
+import { MAX_PAGE, type SearchParams, getProfiles } from "@venuecms/sdk-next";
 import { connection } from "next/server";
 
+import { PaginationLinks } from "@/components/Pagination";
 import { ProfilesList } from "@/components/ProfileList";
+import { buildPageHref } from "@/components/utils/searchParams";
 
-// One page of profiles, matching the roster template-liminal lists and the cap
-// /events already puts on its own index. Records past it are not reachable from
-// this page; giving it a pager is a follow-up, not a silent detail.
-const PROFILE_LIMIT = 99;
+/** The page size /archive and /shop use, this template's other paged indexes. */
+export const PROFILES_PER_PAGE = 50;
 
 /**
- * The records half of the profile listing. Draws only the grid: its frame, its
+ * The records half of the profile listing, and its pager. The frame, the
  * heading and the page's own body live in `ProfilesListSection`, above the
  * Suspense boundary, so none of them wait on this fetch or vanish with it.
  */
-export async function ProfilesListContent() {
+export async function ProfilesListContent({
+  currentPage,
+  basePath,
+  searchParams = {},
+}: {
+  currentPage: number;
+  /** Path the pager builds hrefs against; only the route knows it. */
+  basePath: string;
+  searchParams?: SearchParams;
+}) {
   await connection();
 
   // No `dir`/`orderBy`: a `profileListing` block sends neither unless its author
   // picks one, so leaving them off is what makes this page and that block order
   // the same roster the same way.
-  const { data: profiles } = await getProfiles({ limit: PROFILE_LIMIT });
+  const { data: profiles } = await getProfiles({
+    page: currentPage,
+    limit: PROFILES_PER_PAGE,
+  });
 
   // The SDK reports a failed read as absent data rather than throwing, which
   // would otherwise render an outage as an empty roster — a cached 200 saying
@@ -28,12 +40,45 @@ export async function ProfilesListContent() {
     throw new Error("The profiles endpoint could not be read.");
   }
 
+  const { records } = profiles;
+
+  // `count` is optional on the profiles response, so unlike /shop there is no
+  // total to divide into pages: a page that came back full is the only evidence
+  // another may follow. The SDK pages a `profileListing` block by that same
+  // rule, which is what keeps the two surfaces agreeing where the roster ends.
+  //
+  // It does mean a roster whose length is an exact multiple of the page size
+  // offers one link to an empty page. That page keeps its pager rather than
+  // stranding whoever followed it.
+  const prevHref =
+    currentPage > 0
+      ? buildPageHref(basePath, searchParams, currentPage - 1)
+      : null;
+
+  const nextHref =
+    records.length === PROFILES_PER_PAGE && currentPage < MAX_PAGE
+      ? buildPageHref(basePath, searchParams, currentPage + 1)
+      : null;
+
   // No site read, and so no `notFound` on a failed one: a profile card draws
   // from the profile alone, and asking would only add a request that could
   // take the page down with it.
-  return profiles.records.length ? (
-    <ProfilesList profiles={profiles.records} />
-  ) : (
-    "No artists found"
+  return (
+    <>
+      {records.length ? (
+        <ProfilesList profiles={records} />
+      ) : (
+        "No artists found"
+      )}
+      {prevHref || nextHref ? (
+        <PaginationLinks
+          prevHref={prevHref}
+          nextHref={nextHref}
+          // A PROFILELIST page can carry several pagers — every listing block
+          // in its body brings one — so this landmark needs a name of its own.
+          label="Artists pagination"
+        />
+      ) : null}
+    </>
   );
 }

--- a/src/components/ProfilesPage/ProfilesListContent.tsx
+++ b/src/components/ProfilesPage/ProfilesListContent.tsx
@@ -1,0 +1,49 @@
+import { getProfiles } from "@venuecms/sdk-next";
+import { connection } from "next/server";
+import type { ReactNode } from "react";
+
+import { ProfilesList } from "@/components/ProfileList";
+import { ColumnLeft, ColumnRight, TwoColumnLayout } from "@/components/layout";
+
+// One page of profiles, matching the roster template-liminal lists. The
+// endpoint pages, but no route here does: profiles are a cast list, not a feed,
+// and `count` is optional on that response, so a pager could not size itself.
+const PROFILE_LIMIT = 99;
+
+export async function ProfilesListContent({
+  title,
+  children,
+}: {
+  /**
+   * Heading. Always the listing page's own: unlike events and shop, this
+   * template has no /profiles route and so no page record to read one from.
+   */
+  title?: string;
+  children?: ReactNode;
+}) {
+  await connection();
+
+  const { data: profiles } = await getProfiles({
+    limit: PROFILE_LIMIT,
+    dir: "desc",
+  });
+
+  // No site read, and so no `notFound` on a failed one: a profile card draws
+  // from the profile alone, and asking would only add a request that could
+  // take the page down with it.
+  return (
+    <TwoColumnLayout>
+      <ColumnLeft className="text-sm text-secondary">
+        <p className="pb-8 text-primary">{title ?? "artists"}</p>
+      </ColumnLeft>
+      <ColumnRight>
+        {children}
+        {profiles?.records.length ? (
+          <ProfilesList profiles={profiles.records} />
+        ) : (
+          "No artists found"
+        )}
+      </ColumnRight>
+    </TwoColumnLayout>
+  );
+}

--- a/src/components/ProfilesPage/ProfilesListSection.tsx
+++ b/src/components/ProfilesPage/ProfilesListSection.tsx
@@ -1,3 +1,4 @@
+import type { SearchParams } from "@venuecms/sdk-next";
 import { Suspense } from "react";
 import type { ReactNode } from "react";
 
@@ -51,6 +52,9 @@ function ProfilesListSkeleton() {
  */
 export function ProfilesListSection({
   title,
+  currentPage,
+  basePath,
+  searchParams,
   children,
 }: {
   /**
@@ -58,6 +62,10 @@ export function ProfilesListSection({
    * template has no /profiles route and so no page record to read one from.
    */
   title?: string;
+  currentPage: number;
+  /** Path the pager builds hrefs against; only the route knows it. */
+  basePath: string;
+  searchParams?: SearchParams;
   /** The page's own body, rendered above the records. */
   children?: ReactNode;
 }) {
@@ -75,7 +83,11 @@ export function ProfilesListSection({
         {children}
         <ErrorBoundary fallback={<ProfilesListError />}>
           <Suspense fallback={<ProfilesListSkeleton />}>
-            <ProfilesListContent />
+            <ProfilesListContent
+              currentPage={currentPage}
+              basePath={basePath}
+              searchParams={searchParams}
+            />
           </Suspense>
         </ErrorBoundary>
       </ColumnRight>

--- a/src/components/ProfilesPage/ProfilesListSection.tsx
+++ b/src/components/ProfilesPage/ProfilesListSection.tsx
@@ -1,0 +1,68 @@
+import { Suspense } from "react";
+import type { ReactNode } from "react";
+
+import {
+  ColumnLeft,
+  ColumnRight,
+  TwoColumnLayout,
+  TwoSubColumnLayout,
+} from "@/components/layout";
+import { Skeleton } from "@/components/ui/Input/Skeleton";
+import { ErrorBoundary } from "@/components/utils/ErrorBoundary";
+
+import { ProfilesListContent } from "./ProfilesListContent";
+
+function ProfilesListError() {
+  return (
+    <TwoColumnLayout>
+      <ColumnLeft className="text-sm text-secondary" />
+      <ColumnRight>
+        <p className="text-secondary">
+          Unable to load artists. Please try refreshing the page.
+        </p>
+      </ColumnRight>
+    </TwoColumnLayout>
+  );
+}
+
+function ProfilesListSkeleton() {
+  return (
+    <TwoColumnLayout>
+      <ColumnLeft className="text-sm text-secondary">
+        <div className="pb-8">
+          <Skeleton className="w-32" />
+        </div>
+      </ColumnLeft>
+      <ColumnRight>
+        <TwoSubColumnLayout>
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="flex flex-col gap-6">
+              <Skeleton className="aspect-video w-full" />
+              <Skeleton className="w-32" />
+              <div className="flex flex-col gap-1">
+                <Skeleton className="w-full" />
+                <Skeleton className="w-3/4" />
+              </div>
+            </div>
+          ))}
+        </TwoSubColumnLayout>
+      </ColumnRight>
+    </TwoColumnLayout>
+  );
+}
+
+export function ProfilesListSection({
+  title,
+  children,
+}: {
+  title?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <ErrorBoundary fallback={<ProfilesListError />}>
+      <Suspense fallback={<ProfilesListSkeleton />}>
+        <ProfilesListContent title={title}>{children}</ProfilesListContent>
+      </Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/src/components/ProfilesPage/ProfilesListSection.tsx
+++ b/src/components/ProfilesPage/ProfilesListSection.tsx
@@ -14,55 +14,71 @@ import { ProfilesListContent } from "./ProfilesListContent";
 
 function ProfilesListError() {
   return (
-    <TwoColumnLayout>
-      <ColumnLeft className="text-sm text-secondary" />
-      <ColumnRight>
-        <p className="text-secondary">
-          Unable to load artists. Please try refreshing the page.
-        </p>
-      </ColumnRight>
-    </TwoColumnLayout>
+    <p className="text-secondary">
+      Unable to load artists. Please try refreshing the page.
+    </p>
   );
 }
 
 function ProfilesListSkeleton() {
   return (
-    <TwoColumnLayout>
-      <ColumnLeft className="text-sm text-secondary">
-        <div className="pb-8">
+    <TwoSubColumnLayout>
+      {[1, 2, 3, 4].map((i) => (
+        <div key={i} className="flex flex-col gap-6">
+          {/* `h-auto` so tailwind-merge drops Skeleton's own `h-4`, which would
+              otherwise win over the aspect ratio and collapse the card to a bar. */}
+          <Skeleton className="aspect-video h-auto w-full" />
           <Skeleton className="w-32" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="w-full" />
+            <Skeleton className="w-3/4" />
+          </div>
         </div>
-      </ColumnLeft>
-      <ColumnRight>
-        <TwoSubColumnLayout>
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="flex flex-col gap-6">
-              <Skeleton className="aspect-video w-full" />
-              <Skeleton className="w-32" />
-              <div className="flex flex-col gap-1">
-                <Skeleton className="w-full" />
-                <Skeleton className="w-3/4" />
-              </div>
-            </div>
-          ))}
-        </TwoSubColumnLayout>
-      </ColumnRight>
-    </TwoColumnLayout>
+      ))}
+    </TwoSubColumnLayout>
   );
 }
 
+/**
+ * The frame of the profile listing: the /events and /archive two-column index,
+ * since this template has no /profiles route of its own to mirror.
+ *
+ * The heading and the page's own body sit *outside* the boundaries on purpose.
+ * Both are already in hand — neither costs a request — so putting them under
+ * the Suspense would hide readable content behind the roster's skeleton and
+ * shift the layout when it resolved, and putting them under the ErrorBoundary
+ * would delete an author's prose because an unrelated fetch failed.
+ */
 export function ProfilesListSection({
   title,
   children,
 }: {
+  /**
+   * Heading. Always the listing page's own: unlike events and shop, this
+   * template has no /profiles route and so no page record to read one from.
+   */
   title?: string;
+  /** The page's own body, rendered above the records. */
   children?: ReactNode;
 }) {
+  // Emptiness, not absence: the route reads the title off the page's localized
+  // content, which is blank rather than missing for a locale saved without one,
+  // and `??` would keep that and draw an empty heading column.
+  const heading = title?.trim() ? title : "artists";
+
   return (
-    <ErrorBoundary fallback={<ProfilesListError />}>
-      <Suspense fallback={<ProfilesListSkeleton />}>
-        <ProfilesListContent title={title}>{children}</ProfilesListContent>
-      </Suspense>
-    </ErrorBoundary>
+    <TwoColumnLayout>
+      <ColumnLeft className="text-sm text-secondary">
+        <p className="pb-8 text-primary">{heading}</p>
+      </ColumnLeft>
+      <ColumnRight>
+        {children}
+        <ErrorBoundary fallback={<ProfilesListError />}>
+          <Suspense fallback={<ProfilesListSkeleton />}>
+            <ProfilesListContent />
+          </Suspense>
+        </ErrorBoundary>
+      </ColumnRight>
+    </TwoColumnLayout>
   );
 }

--- a/src/components/ProfilesPage/index.ts
+++ b/src/components/ProfilesPage/index.ts
@@ -1,0 +1,1 @@
+export { ProfilesListSection } from "./ProfilesListSection";

--- a/src/components/ShopPage/ProductsLayout.tsx
+++ b/src/components/ShopPage/ProductsLayout.tsx
@@ -1,0 +1,13 @@
+/**
+ * The frame a products listing sits in — and only the frame.
+ *
+ * It draws no products of its own. /shop renders `ProductsListSection` into it;
+ * a PRODUCTLIST page renders its own body into it, and the product listing block
+ * in that body is what draws the records. That is the whole point of the split:
+ * a page typed as a product list is an ordinary page whose content happens to
+ * hold a products block, so the layout has no business fetching a second grid
+ * and stacking it under the author's.
+ */
+export const ProductsLayout = ({ children }: { children: React.ReactNode }) => (
+  <section className="py-20">{children}</section>
+);

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -145,6 +145,9 @@ describe("the products listing body", () => {
   // Asserted on what survives rather than on the error copy: the boundary that
   // catches the bailout is a client component, and React hands a suspended
   // boundary's error to the client rather than running its fallback in SSR.
+  // That is also why this cannot see the boundary's *placement* — the body
+  // renders in the server output either way — so the placement itself is
+  // pinned in PageListing/boundaries.test.tsx, where the boundary is stubbed.
   it("keeps the body when the grid fails", async () => {
     siteReadFails = true;
 
@@ -155,8 +158,6 @@ describe("the products listing body", () => {
     );
 
     expect(html).toContain("Season notes");
-    // And does not pass the failure off as a shop that is merely empty.
-    expect(html).not.toContain("No products found");
   });
 });
 

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -1,15 +1,3 @@
-/**
- * The pager, which is the only part of this listing that can be wrong quietly.
- *
- * The grid either shows products or does not, and a reader can see which. A
- * pager pointing at the wrong route still renders two working arrows — they
- * just walk the reader off the page they were on, which is what happens to a
- * page typed as the product listing if this component keeps hardcoding /shop.
- *
- * `connection()` is stubbed because the component calls it to opt out of the
- * prerender, and outside a Next request scope it throws. That is not the
- * behaviour under test.
- */
 import { setConfig } from "@venuecms/sdk-next";
 import { NextIntlClientProvider } from "next-intl";
 import type { ReactNode } from "react";
@@ -25,10 +13,8 @@ vi.mock("@/components/ListProduct", () => ({
   ),
 }));
 
-/** Enough products for the endpoint to report more pages after this one. */
 const COUNT = 120;
 
-/** What the products endpoint hands back for a full first page. */
 const PAGE_SIZE = 50;
 
 const render = async (node: ReactNode) => {

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -85,3 +85,18 @@ describe("the products listing pager", () => {
     expect(html).not.toContain("/shop?page=");
   });
 });
+
+describe("the products listing body", () => {
+  it("renders a body it was handed above the products", async () => {
+    const html = await render(
+      <ProductsListContent locale="en" currentPage={0} basePath="/p/merch">
+        <p>Season notes</p>
+      </ProductsListContent>,
+    );
+
+    expect(html.indexOf("Season notes")).toBeGreaterThan(-1);
+    expect(html.indexOf("Season notes")).toBeLessThan(
+      html.indexOf('data-testid="product"'),
+    );
+  });
+});

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -38,25 +38,36 @@ const requestedUrls = () =>
     );
 
 let productCount = COUNT;
+// `count` is optional on this response, so the pager's countless path needs a
+// mock that can leave it off rather than send a zero.
+let sendCount = true;
+let siteReadFails = false;
 
 beforeEach(() => {
   setConfig({ siteKey: "test-site" });
   productCount = COUNT;
+  sendCount = true;
+  siteReadFails = false;
 
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = input instanceof Request ? input.url : String(input);
 
     if (url.includes("/products")) {
+      const records = Array.from(
+        { length: Math.min(productCount, PAGE_SIZE) },
+        (_, i) => ({ slug: `p${i}`, localizedContent: [] }),
+      );
+
       return new Response(
-        JSON.stringify({
-          records: Array.from(
-            { length: Math.min(productCount, PAGE_SIZE) },
-            (_, i) => ({ slug: `p${i}`, localizedContent: [] }),
-          ),
-          count: productCount,
-        }),
+        JSON.stringify(
+          sendCount ? { records, count: productCount } : { records },
+        ),
         { status: 200, headers: { "content-type": "application/json" } },
       );
+    }
+
+    if (siteReadFails) {
+      return new Response("upstream is down", { status: 500 });
     }
 
     return new Response(
@@ -105,27 +116,26 @@ describe("the products listing pager", () => {
     expect(html).toContain("/shop?page=1");
   });
 
-  it("pages against the page it is rendered on, not /shop", async () => {
+  it("steps both ways from the middle of the listing", async () => {
     const html = await render(
-      <ProductsListSection currentPage={1} basePath="/p/merch" />,
+      <ProductsListSection currentPage={1} basePath="/shop" />,
     );
 
-    expect(html).toContain("/p/merch?page=0");
-    expect(html).toContain("/p/merch?page=2");
-    expect(html).not.toContain("/shop?page=");
+    expect(html).toContain("/shop?page=0");
+    expect(html).toContain("/shop?page=2");
   });
 
-  // Without this the body's listing block snaps back to its first page.
-  it("keeps a listing block's own param when paging the route", async () => {
+  // Without this a listing block elsewhere on the page snaps back to page one.
+  it("keeps every other param when paging the route", async () => {
     const html = await render(
       <ProductsListSection
         currentPage={1}
-        basePath="/p/merch"
+        basePath="/shop"
         searchParams={{ page: "1", evt_9k3z1: "3" }}
       />,
     );
 
-    expect(html).toContain("/p/merch?evt_9k3z1=3&amp;page=2");
+    expect(html).toContain("/shop?evt_9k3z1=3&amp;page=2");
   });
 
   it("draws no pager for a shop that fits on one page", async () => {
@@ -137,6 +147,71 @@ describe("the products listing pager", () => {
 
     expect(html).not.toContain("?page=");
   });
+
+  // A count of zero is an empty shop, not a missing count. Reading it as the
+  // latter offered ninety-nine pages of "No products found".
+  it("draws no pager for an empty shop", async () => {
+    productCount = 0;
+
+    const html = await render(
+      <ProductsListSection currentPage={0} basePath="/shop" />,
+    );
+
+    expect(html).toContain("No products found");
+    expect(html).not.toContain("?page=");
+  });
+
+  /**
+   * `count` is optional on this response. Without one the pager can only follow
+   * the records: a full page might have another behind it, a short one is the
+   * last — and an empty page past the end still owes the reader a way back.
+   */
+  describe("when the endpoint sends no count", () => {
+    beforeEach(() => {
+      sendCount = false;
+    });
+
+    it("offers a next page while full pages keep coming back", async () => {
+      const html = await render(
+        <ProductsListSection currentPage={0} basePath="/shop" />,
+      );
+
+      expect(html).toContain("/shop?page=1");
+    });
+
+    it("offers no next page once a short page arrives", async () => {
+      productCount = 3;
+
+      const html = await render(
+        <ProductsListSection currentPage={0} basePath="/shop" />,
+      );
+
+      expect(html).not.toContain("?page=");
+    });
+
+    it("keeps a way back off a page past the end", async () => {
+      productCount = 0;
+
+      const html = await render(
+        <ProductsListSection currentPage={4} basePath="/shop" />,
+      );
+
+      expect(html).toContain("/shop?page=3");
+      expect(html).not.toContain("/shop?page=5");
+    });
+  });
+});
+
+// `getSite()` reporting a failed read as absent data is the one thing standing
+// between a siteless product and `ListProduct`, which types it non-null.
+it("bails out rather than drawing products without a site", async () => {
+  siteReadFails = true;
+
+  const html = await render(
+    <ProductsListSection currentPage={0} basePath="/shop" />,
+  );
+
+  expect(html).not.toContain('data-testid="products"');
 });
 
 // The grid has no heading slot, so the record that would only have supplied a

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -5,6 +5,7 @@ import { renderToReadableStream } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ProductsListContent } from "./ProductsListContent";
+import { ProductsListSection } from "./ProductsListSection";
 
 vi.mock("next/server", () => ({ connection: async () => {} }));
 vi.mock("@/components/ListProduct", () => ({
@@ -12,6 +13,10 @@ vi.mock("@/components/ListProduct", () => ({
     <div data-testid="product">{product.slug}</div>
   ),
 }));
+
+// Containment alone would pass with the body drawn outside the listing, so the
+// assertions read the section that should hold it.
+const listingSection = (html: string) => html.split("<section")[1] ?? "";
 
 const COUNT = 120;
 
@@ -84,19 +89,57 @@ describe("the products listing pager", () => {
     expect(html).toContain("/p/merch?page=2");
     expect(html).not.toContain("/shop?page=");
   });
+
+  // Without this the body's listing block snaps back to its first page.
+  it("keeps a listing block's own param when paging the route", async () => {
+    const html = await render(
+      <ProductsListContent
+        locale="en"
+        currentPage={1}
+        basePath="/p/merch"
+        searchParams={{ page: "1", evt_9k3z1: "3" }}
+      />,
+    );
+
+    expect(html).toContain("/p/merch?evt_9k3z1=3&amp;page=2");
+  });
 });
 
 describe("the products listing body", () => {
   it("renders a body it was handed above the products", async () => {
-    const html = await render(
-      <ProductsListContent locale="en" currentPage={0} basePath="/p/merch">
-        <p>Season notes</p>
-      </ProductsListContent>,
+    const section = listingSection(
+      await render(
+        <ProductsListContent locale="en" currentPage={0} basePath="/p/merch">
+          <p>Season notes</p>
+        </ProductsListContent>,
+      ),
     );
 
-    expect(html.indexOf("Season notes")).toBeGreaterThan(-1);
-    expect(html.indexOf("Season notes")).toBeLessThan(
-      html.indexOf('data-testid="product"'),
+    expect(section.indexOf("Season notes")).toBeGreaterThan(-1);
+    expect(section.indexOf("Season notes")).toBeLessThan(
+      section.indexOf('data-testid="product"'),
     );
+  });
+
+  it("renders no body wrapper for the /shop route, which passes none", async () => {
+    const html = await render(
+      <ProductsListContent locale="en" currentPage={0} basePath="/shop" />,
+    );
+
+    expect(html).not.toContain('class="pb-20"');
+  });
+});
+
+describe("the products listing section", () => {
+  it("hands the body it was given to the content it wraps", async () => {
+    const section = listingSection(
+      await render(
+        <ProductsListSection locale="en" currentPage={0} basePath="/p/merch">
+          <p>Season notes</p>
+        </ProductsListSection>,
+      ),
+    );
+
+    expect(section).toContain("Season notes");
   });
 });

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * The pager, which is the only part of this listing that can be wrong quietly.
+ *
+ * The grid either shows products or does not, and a reader can see which. A
+ * pager pointing at the wrong route still renders two working arrows — they
+ * just walk the reader off the page they were on, which is what happens to a
+ * page typed as the product listing if this component keeps hardcoding /shop.
+ *
+ * `connection()` is stubbed because the component calls it to opt out of the
+ * prerender, and outside a Next request scope it throws. That is not the
+ * behaviour under test.
+ */
+import { setConfig } from "@venuecms/sdk-next";
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { renderToReadableStream } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProductsListContent } from "./ProductsListContent";
+
+vi.mock("next/server", () => ({ connection: async () => {} }));
+vi.mock("@/components/ListProduct", () => ({
+  ListProduct: ({ product }: { product: { slug: string } }) => (
+    <div data-testid="product">{product.slug}</div>
+  ),
+}));
+
+/** Enough products for the endpoint to report more pages after this one. */
+const COUNT = 120;
+
+/** What the products endpoint hands back for a full first page. */
+const PAGE_SIZE = 50;
+
+const render = async (node: ReactNode) => {
+  const stream = await renderToReadableStream(
+    <NextIntlClientProvider locale="en" messages={{}}>
+      {node}
+    </NextIntlClientProvider>,
+  );
+  await stream.allReady;
+  return new Response(stream).text();
+};
+
+beforeEach(() => {
+  setConfig({ siteKey: "test-site" });
+
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = input instanceof Request ? input.url : String(input);
+
+    let body: unknown = {
+      id: "site-id",
+      timeZone: "Europe/Berlin",
+      settings: {},
+    };
+
+    if (url.includes("/products")) {
+      body = {
+        records: Array.from({ length: PAGE_SIZE }, (_, i) => ({
+          slug: `p${i}`,
+          localizedContent: [],
+        })),
+        count: COUNT,
+      };
+    } else if (url.includes("/pages")) {
+      body = {
+        id: "page-id",
+        slug: "shop",
+        localizedContent: [{ siteId: "site-id", locale: "en", title: "Shop" }],
+      };
+    }
+
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("the products listing pager", () => {
+  it("pages against the /shop route when that is what rendered it", async () => {
+    const html = await render(
+      <ProductsListContent locale="en" currentPage={0} basePath="/shop" />,
+    );
+
+    expect(html).toContain("/shop?page=1");
+  });
+
+  it("pages against the page it is rendered on, not /shop", async () => {
+    const html = await render(
+      <ProductsListContent locale="en" currentPage={1} basePath="/p/merch" />,
+    );
+
+    expect(html).toContain("/p/merch?page=0");
+    expect(html).toContain("/p/merch?page=2");
+    expect(html).not.toContain("/shop?page=");
+  });
+});

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -8,14 +8,10 @@ import { ProductsListSection } from "./ProductsListSection";
 
 vi.mock("next/server", () => ({ connection: async () => {} }));
 vi.mock("@/components/ListProduct", () => ({
-  ListProduct: ({ product }: { product: { slug: string } }) => (
-    <div data-testid="product">{product.slug}</div>
+  ProductsList: ({ products }: { products: Array<{ slug: string }> }) => (
+    <div data-testid="products">{products.map((p) => p.slug).join(",")}</div>
   ),
 }));
-
-// Containment alone would pass with the body drawn outside the listing, so the
-// assertions read the section that should hold it.
-const listingSection = (html: string) => html.split("<section")[1] ?? "";
 
 const COUNT = 120;
 
@@ -41,11 +37,11 @@ const requestedUrls = () =>
       input instanceof Request ? input.url : String(input),
     );
 
-let siteReadFails = false;
+let productCount = COUNT;
 
 beforeEach(() => {
   setConfig({ siteKey: "test-site" });
-  siteReadFails = false;
+  productCount = COUNT;
 
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = input instanceof Request ? input.url : String(input);
@@ -53,18 +49,14 @@ beforeEach(() => {
     if (url.includes("/products")) {
       return new Response(
         JSON.stringify({
-          records: Array.from({ length: PAGE_SIZE }, (_, i) => ({
-            slug: `p${i}`,
-            localizedContent: [],
-          })),
-          count: COUNT,
+          records: Array.from(
+            { length: Math.min(productCount, PAGE_SIZE) },
+            (_, i) => ({ slug: `p${i}`, localizedContent: [] }),
+          ),
+          count: productCount,
         }),
         { status: 200, headers: { "content-type": "application/json" } },
       );
-    }
-
-    if (siteReadFails) {
-      return new Response("upstream is down", { status: 500 });
     }
 
     return new Response(
@@ -80,6 +72,28 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe("the products listing", () => {
+  // The grid is `ProductsList`, shared with the product listing block, so a
+  // block and /shop draw the same thing rather than two grids that drift.
+  it("draws its records through the shared products grid", async () => {
+    const html = await render(
+      <ProductsListSection currentPage={0} basePath="/shop" />,
+    );
+
+    expect(html).toContain('data-testid="products"');
+    expect(html).toContain("p0,p1");
+  });
+
+  // The frame is `ProductsLayout`, which the route wraps around this.
+  it("draws no frame of its own, leaving that to the layout", async () => {
+    const html = await render(
+      <ProductsListSection currentPage={0} basePath="/shop" />,
+    );
+
+    expect(html).not.toContain("<section");
+  });
 });
 
 describe("the products listing pager", () => {
@@ -113,51 +127,15 @@ describe("the products listing pager", () => {
 
     expect(html).toContain("/p/merch?evt_9k3z1=3&amp;page=2");
   });
-});
 
-describe("the products listing body", () => {
-  it("renders a body it was handed above the products", async () => {
-    const section = listingSection(
-      await render(
-        <ProductsListSection currentPage={0} basePath="/p/merch">
-          <p>Season notes</p>
-        </ProductsListSection>,
-      ),
-    );
+  it("draws no pager for a shop that fits on one page", async () => {
+    productCount = 3;
 
-    expect(section.indexOf("Season notes")).toBeGreaterThan(-1);
-    expect(section.indexOf("Season notes")).toBeLessThan(
-      section.indexOf('data-testid="product"'),
-    );
-  });
-
-  it("renders no body wrapper for the /shop route, which passes none", async () => {
     const html = await render(
       <ProductsListSection currentPage={0} basePath="/shop" />,
     );
 
-    expect(html).not.toContain('class="pb-20"');
-  });
-
-  // The body costs no request of its own, so it sits outside the boundaries: a
-  // failed grid read has no business taking an author's prose down with it.
-  //
-  // Asserted on what survives rather than on the error copy: the boundary that
-  // catches the bailout is a client component, and React hands a suspended
-  // boundary's error to the client rather than running its fallback in SSR.
-  // That is also why this cannot see the boundary's *placement* — the body
-  // renders in the server output either way — so the placement itself is
-  // pinned in PageListing/boundaries.test.tsx, where the boundary is stubbed.
-  it("keeps the body when the grid fails", async () => {
-    siteReadFails = true;
-
-    const html = await render(
-      <ProductsListSection currentPage={0} basePath="/p/merch">
-        <p>Season notes</p>
-      </ProductsListSection>,
-    );
-
-    expect(html).toContain("Season notes");
+    expect(html).not.toContain("?page=");
   });
 });
 

--- a/src/components/ShopPage/ProductsListContent.test.tsx
+++ b/src/components/ShopPage/ProductsListContent.test.tsx
@@ -4,7 +4,6 @@ import type { ReactNode } from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ProductsListContent } from "./ProductsListContent";
 import { ProductsListSection } from "./ProductsListSection";
 
 vi.mock("next/server", () => ({ connection: async () => {} }));
@@ -27,43 +26,55 @@ const render = async (node: ReactNode) => {
     <NextIntlClientProvider locale="en" messages={{}}>
       {node}
     </NextIntlClientProvider>,
+    // The grid's boundary is expected to catch a failed read; without this the
+    // recoverable error still reaches the console and reads as a test error.
+    { onError: () => {} },
   );
   await stream.allReady;
   return new Response(stream).text();
 };
 
+const requestedUrls = () =>
+  vi
+    .mocked(globalThis.fetch)
+    .mock.calls.map(([input]) =>
+      input instanceof Request ? input.url : String(input),
+    );
+
+let siteReadFails = false;
+
 beforeEach(() => {
   setConfig({ siteKey: "test-site" });
+  siteReadFails = false;
 
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = input instanceof Request ? input.url : String(input);
 
-    let body: unknown = {
-      id: "site-id",
-      timeZone: "Europe/Berlin",
-      settings: {},
-    };
-
     if (url.includes("/products")) {
-      body = {
-        records: Array.from({ length: PAGE_SIZE }, (_, i) => ({
-          slug: `p${i}`,
-          localizedContent: [],
-        })),
-        count: COUNT,
-      };
-    } else if (url.includes("/pages")) {
-      body = {
-        id: "page-id",
-        slug: "shop",
-        localizedContent: [{ siteId: "site-id", locale: "en", title: "Shop" }],
-      };
+      return new Response(
+        JSON.stringify({
+          records: Array.from({ length: PAGE_SIZE }, (_, i) => ({
+            slug: `p${i}`,
+            localizedContent: [],
+          })),
+          count: COUNT,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
     }
 
-    return new Response(JSON.stringify(body), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
+    if (siteReadFails) {
+      return new Response("upstream is down", { status: 500 });
+    }
+
+    return new Response(
+      JSON.stringify({
+        id: "site-id",
+        timeZone: "Europe/Berlin",
+        settings: {},
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
   });
 });
 
@@ -74,7 +85,7 @@ afterEach(() => {
 describe("the products listing pager", () => {
   it("pages against the /shop route when that is what rendered it", async () => {
     const html = await render(
-      <ProductsListContent locale="en" currentPage={0} basePath="/shop" />,
+      <ProductsListSection currentPage={0} basePath="/shop" />,
     );
 
     expect(html).toContain("/shop?page=1");
@@ -82,7 +93,7 @@ describe("the products listing pager", () => {
 
   it("pages against the page it is rendered on, not /shop", async () => {
     const html = await render(
-      <ProductsListContent locale="en" currentPage={1} basePath="/p/merch" />,
+      <ProductsListSection currentPage={1} basePath="/p/merch" />,
     );
 
     expect(html).toContain("/p/merch?page=0");
@@ -93,8 +104,7 @@ describe("the products listing pager", () => {
   // Without this the body's listing block snaps back to its first page.
   it("keeps a listing block's own param when paging the route", async () => {
     const html = await render(
-      <ProductsListContent
-        locale="en"
+      <ProductsListSection
         currentPage={1}
         basePath="/p/merch"
         searchParams={{ page: "1", evt_9k3z1: "3" }}
@@ -109,9 +119,9 @@ describe("the products listing body", () => {
   it("renders a body it was handed above the products", async () => {
     const section = listingSection(
       await render(
-        <ProductsListContent locale="en" currentPage={0} basePath="/p/merch">
+        <ProductsListSection currentPage={0} basePath="/p/merch">
           <p>Season notes</p>
-        </ProductsListContent>,
+        </ProductsListSection>,
       ),
     );
 
@@ -123,23 +133,37 @@ describe("the products listing body", () => {
 
   it("renders no body wrapper for the /shop route, which passes none", async () => {
     const html = await render(
-      <ProductsListContent locale="en" currentPage={0} basePath="/shop" />,
+      <ProductsListSection currentPage={0} basePath="/shop" />,
     );
 
     expect(html).not.toContain('class="pb-20"');
   });
-});
 
-describe("the products listing section", () => {
-  it("hands the body it was given to the content it wraps", async () => {
-    const section = listingSection(
-      await render(
-        <ProductsListSection locale="en" currentPage={0} basePath="/p/merch">
-          <p>Season notes</p>
-        </ProductsListSection>,
-      ),
+  // The body costs no request of its own, so it sits outside the boundaries: a
+  // failed grid read has no business taking an author's prose down with it.
+  //
+  // Asserted on what survives rather than on the error copy: the boundary that
+  // catches the bailout is a client component, and React hands a suspended
+  // boundary's error to the client rather than running its fallback in SSR.
+  it("keeps the body when the grid fails", async () => {
+    siteReadFails = true;
+
+    const html = await render(
+      <ProductsListSection currentPage={0} basePath="/p/merch">
+        <p>Season notes</p>
+      </ProductsListSection>,
     );
 
-    expect(section).toContain("Season notes");
+    expect(html).toContain("Season notes");
+    // And does not pass the failure off as a shop that is merely empty.
+    expect(html).not.toContain("No products found");
   });
+});
+
+// The grid has no heading slot, so the record that would only have supplied a
+// title is not worth a round trip on every render.
+it("reads no page record for a title it has nowhere to draw", async () => {
+  await render(<ProductsListSection currentPage={0} basePath="/shop" />);
+
+  expect(requestedUrls().some((url) => url.includes("/pages"))).toBe(false);
 });

--- a/src/components/ShopPage/ProductsListContent.tsx
+++ b/src/components/ShopPage/ProductsListContent.tsx
@@ -11,9 +11,19 @@ const ITEMS_PER_PAGE = 50;
 export async function ProductsListContent({
   locale,
   currentPage,
+  basePath,
 }: {
   locale: string;
   currentPage: number;
+  /**
+   * The path the pager builds its hrefs against.
+   *
+   * Passed in rather than hardcoded to `/shop` because this listing is no
+   * longer only that route: a page typed as the product listing pages against
+   * its own `/p/<slug>`, and a pager that walked a reader back to `/shop`
+   * would fail silently — the links render, they just leave the page.
+   */
+  basePath: string;
 }) {
   await connection();
 
@@ -68,7 +78,7 @@ export async function ProductsListContent({
         <Pagination
           currentPage={currentPage}
           totalPages={totalPages - 1}
-          baseUrl={`/shop`}
+          baseUrl={basePath}
         />
       ) : null}
     </section>

--- a/src/components/ShopPage/ProductsListContent.tsx
+++ b/src/components/ShopPage/ProductsListContent.tsx
@@ -3,15 +3,18 @@ import { getProducts, getSite } from "@venuecms/sdk-next";
 import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
-import { ListProduct } from "@/components/ListProduct";
+import { ProductsList } from "@/components/ListProduct";
 import { Pagination } from "@/components/Pagination";
 
 const ITEMS_PER_PAGE = 50;
 
 /**
- * The records half of the products listing, and its pager. The frame and any
- * page body live in `ProductsListSection`, above the Suspense boundary, so
- * neither waits on this fetch or vanishes with it.
+ * The records half of the products listing, and its pager. The frame lives in
+ * `ProductsLayout`, above the Suspense boundary, so it neither waits on this
+ * fetch nor vanishes with it.
+ *
+ * The grid itself is `ProductsList`, shared with the product listing block: a
+ * block an author drops into a page draws the same thing this route does.
  *
  * No page record is read: this grid has no heading slot to put a title in.
  */
@@ -39,36 +42,23 @@ export async function ProductsListContent({
     notFound();
   }
 
-  // Calculate total pages
+  const records = products?.records ?? [];
+
   const totalPages = products?.count
     ? Math.ceil(products.count / ITEMS_PER_PAGE)
     : 100;
 
-  const topProducts = products?.records.slice(0, 4);
-  const moreProducts = products?.records.slice(4);
-
   return (
     <>
-      <div className="grid gap-8 pb-20 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
-        {topProducts?.length
-          ? topProducts.map((product) => (
-              <ListProduct
-                key={product.slug}
-                featured={true}
-                product={product}
-                site={site}
-              />
-            ))
-          : "No products found"}
-      </div>
-      {moreProducts?.length ? (
-        <div className="grid grid-cols-2 gap-8 sm:max-w-full lg:grid-cols-[repeat(4,minmax(1rem,32rem))] xl:grid-cols-[repeat(6,minmax(1rem,32rem))]">
-          {moreProducts.map((product) => (
-            <ListProduct key={product.slug} product={product} site={site} />
-          ))}
-        </div>
-      ) : null}
-      {moreProducts?.length && totalPages > 1 ? (
+      {records.length ? (
+        <ProductsList products={records} site={site} />
+      ) : (
+        "No products found"
+      )}
+      {/* Gated on the page count alone. Gating on there being records past the
+          first row, as this once did, dropped the pager on a short last page —
+          which is exactly where a reader most needs the link back. */}
+      {totalPages > 1 ? (
         <Pagination
           currentPage={currentPage}
           totalPages={totalPages - 1}

--- a/src/components/ShopPage/ProductsListContent.tsx
+++ b/src/components/ShopPage/ProductsListContent.tsx
@@ -15,14 +15,7 @@ export async function ProductsListContent({
 }: {
   locale: string;
   currentPage: number;
-  /**
-   * The path the pager builds its hrefs against.
-   *
-   * Passed in rather than hardcoded to `/shop` because this listing is no
-   * longer only that route: a page typed as the product listing pages against
-   * its own `/p/<slug>`, and a pager that walked a reader back to `/shop`
-   * would fail silently — the links render, they just leave the page.
-   */
+  /** Path the pager builds hrefs against; a listing page pages against its own /p/<slug>. */
   basePath: string;
 }) {
   await connection();

--- a/src/components/ShopPage/ProductsListContent.tsx
+++ b/src/components/ShopPage/ProductsListContent.tsx
@@ -12,11 +12,14 @@ export async function ProductsListContent({
   locale,
   currentPage,
   basePath,
+  children,
 }: {
   locale: string;
   currentPage: number;
   /** Path the pager builds hrefs against; a listing page pages against its own /p/<slug>. */
   basePath: string;
+  /** The page's body, above the grid; absent on the `/shop` route. */
+  children?: React.ReactNode;
 }) {
   await connection();
 
@@ -48,6 +51,7 @@ export async function ProductsListContent({
 
   return (
     <section className="py-20">
+      {children ? <div className="pb-20">{children}</div> : null}
       <div className="grid gap-8 pb-20 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
         {topProducts?.length
           ? topProducts.map((product) => (

--- a/src/components/ShopPage/ProductsListContent.tsx
+++ b/src/components/ShopPage/ProductsListContent.tsx
@@ -44,9 +44,24 @@ export async function ProductsListContent({
 
   const records = products?.records ?? [];
 
-  const totalPages = products?.count
-    ? Math.ceil(products.count / ITEMS_PER_PAGE)
-    : 100;
+  /**
+   * Pages the endpoint's own answer implies.
+   *
+   * `count` is optional on this response, so a missing one cannot be read as
+   * "no pages" — but nor can it be read as the open-ended hundred this used to
+   * assume, which offered ninety-nine dead links over a single screen. Without
+   * a count the only honest claim is that a full page might have another behind
+   * it and a short one is the last.
+   *
+   * Tested for presence rather than truthiness: a count of zero is an empty
+   * shop, which is exactly the case a truthiness check sent down the fallback.
+   */
+  const totalPages =
+    products?.count != null
+      ? Math.ceil(products.count / ITEMS_PER_PAGE)
+      : records.length < ITEMS_PER_PAGE
+        ? currentPage + 1
+        : currentPage + 2;
 
   return (
     <>
@@ -60,7 +75,10 @@ export async function ProductsListContent({
           which is exactly where a reader most needs the link back. */}
       {totalPages > 1 ? (
         <Pagination
-          currentPage={currentPage}
+          // Clamped to one past the end, so stepping back off a hand-edited
+          // page deep past the last one lands on real records instead of
+          // walking the reader back through empty page after empty page.
+          currentPage={Math.min(currentPage, totalPages)}
           totalPages={totalPages - 1}
           baseUrl={basePath}
           searchParams={searchParams}

--- a/src/components/ShopPage/ProductsListContent.tsx
+++ b/src/components/ShopPage/ProductsListContent.tsx
@@ -1,3 +1,4 @@
+import type { SearchParams } from "@venuecms/sdk-next";
 import { getLocalizedContent } from "@venuecms/sdk-next";
 import { getPage, getProducts, getSite } from "@venuecms/sdk-next";
 import { notFound } from "next/navigation";
@@ -12,13 +13,14 @@ export async function ProductsListContent({
   locale,
   currentPage,
   basePath,
+  searchParams,
   children,
 }: {
   locale: string;
   currentPage: number;
   /** Path the pager builds hrefs against; a listing page pages against its own /p/<slug>. */
   basePath: string;
-  /** The page's body, above the grid; absent on the `/shop` route. */
+  searchParams?: SearchParams;
   children?: React.ReactNode;
 }) {
   await connection();
@@ -76,6 +78,7 @@ export async function ProductsListContent({
           currentPage={currentPage}
           totalPages={totalPages - 1}
           baseUrl={basePath}
+          searchParams={searchParams}
         />
       ) : null}
     </section>

--- a/src/components/ShopPage/ProductsListContent.tsx
+++ b/src/components/ShopPage/ProductsListContent.tsx
@@ -1,6 +1,5 @@
 import type { SearchParams } from "@venuecms/sdk-next";
-import { getLocalizedContent } from "@venuecms/sdk-next";
-import { getPage, getProducts, getSite } from "@venuecms/sdk-next";
+import { getProducts, getSite } from "@venuecms/sdk-next";
 import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
@@ -9,31 +8,32 @@ import { Pagination } from "@/components/Pagination";
 
 const ITEMS_PER_PAGE = 50;
 
+/**
+ * The records half of the products listing, and its pager. The frame and any
+ * page body live in `ProductsListSection`, above the Suspense boundary, so
+ * neither waits on this fetch or vanishes with it.
+ *
+ * No page record is read: this grid has no heading slot to put a title in.
+ */
 export async function ProductsListContent({
-  locale,
   currentPage,
   basePath,
   searchParams,
-  children,
 }: {
-  locale: string;
   currentPage: number;
   /** Path the pager builds hrefs against; a listing page pages against its own /p/<slug>. */
   basePath: string;
   searchParams?: SearchParams;
-  children?: React.ReactNode;
 }) {
   await connection();
 
-  const [{ data: products }, { data: page }, { data: site }] =
-    await Promise.all([
-      getProducts({
-        page: currentPage,
-        limit: ITEMS_PER_PAGE,
-      }),
-      getPage({ slug: "shop" }),
-      getSite(),
-    ]);
+  const [{ data: products }, { data: site }] = await Promise.all([
+    getProducts({
+      page: currentPage,
+      limit: ITEMS_PER_PAGE,
+    }),
+    getSite(),
+  ]);
 
   if (!site) {
     notFound();
@@ -44,16 +44,11 @@ export async function ProductsListContent({
     ? Math.ceil(products.count / ITEMS_PER_PAGE)
     : 100;
 
-  const pageTitle = page
-    ? getLocalizedContent(page.localizedContent, locale).content.title
-    : "Shop";
-
   const topProducts = products?.records.slice(0, 4);
   const moreProducts = products?.records.slice(4);
 
   return (
-    <section className="py-20">
-      {children ? <div className="pb-20">{children}</div> : null}
+    <>
       <div className="grid gap-8 pb-20 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
         {topProducts?.length
           ? topProducts.map((product) => (
@@ -81,6 +76,6 @@ export async function ProductsListContent({
           searchParams={searchParams}
         />
       ) : null}
-    </section>
+    </>
   );
 }

--- a/src/components/ShopPage/ProductsListSection.tsx
+++ b/src/components/ShopPage/ProductsListSection.tsx
@@ -1,3 +1,4 @@
+import type { SearchParams } from "@venuecms/sdk-next";
 import { Suspense } from "react";
 
 import { Skeleton } from "@/components/ui/Input/Skeleton";
@@ -37,12 +38,13 @@ export function ProductsListSection({
   locale,
   currentPage,
   basePath,
+  searchParams,
   children,
 }: {
   locale: string;
   currentPage: number;
   basePath: string;
-  /** The page's body, above the grid; absent on the `/shop` route. */
+  searchParams?: SearchParams;
   children?: React.ReactNode;
 }) {
   return (
@@ -52,6 +54,7 @@ export function ProductsListSection({
           locale={locale}
           currentPage={currentPage}
           basePath={basePath}
+          searchParams={searchParams}
         >
           {children}
         </ProductsListContent>

--- a/src/components/ShopPage/ProductsListSection.tsx
+++ b/src/components/ShopPage/ProductsListSection.tsx
@@ -36,14 +36,21 @@ function ProductsListSkeleton() {
 export function ProductsListSection({
   locale,
   currentPage,
+  basePath,
 }: {
   locale: string;
   currentPage: number;
+  /** What the pager pages against. See {@link ProductsListContent}. */
+  basePath: string;
 }) {
   return (
     <ErrorBoundary fallback={<ProductsListError />}>
       <Suspense fallback={<ProductsListSkeleton />}>
-        <ProductsListContent locale={locale} currentPage={currentPage} />
+        <ProductsListContent
+          locale={locale}
+          currentPage={currentPage}
+          basePath={basePath}
+        />
       </Suspense>
     </ErrorBoundary>
   );

--- a/src/components/ShopPage/ProductsListSection.tsx
+++ b/src/components/ShopPage/ProductsListSection.tsx
@@ -37,10 +37,13 @@ export function ProductsListSection({
   locale,
   currentPage,
   basePath,
+  children,
 }: {
   locale: string;
   currentPage: number;
   basePath: string;
+  /** The page's body, above the grid; absent on the `/shop` route. */
+  children?: React.ReactNode;
 }) {
   return (
     <ErrorBoundary fallback={<ProductsListError />}>
@@ -49,7 +52,9 @@ export function ProductsListSection({
           locale={locale}
           currentPage={currentPage}
           basePath={basePath}
-        />
+        >
+          {children}
+        </ProductsListContent>
       </Suspense>
     </ErrorBoundary>
   );

--- a/src/components/ShopPage/ProductsListSection.tsx
+++ b/src/components/ShopPage/ProductsListSection.tsx
@@ -8,57 +8,60 @@ import { ProductsListContent } from "./ProductsListContent";
 
 function ProductsListError() {
   return (
-    <section className="py-20">
-      <p className="text-secondary">
-        Unable to load products. Please try refreshing the page.
-      </p>
-    </section>
+    <p className="text-secondary">
+      Unable to load products. Please try refreshing the page.
+    </p>
   );
 }
 
 function ProductsListSkeleton() {
   return (
-    <section className="py-20">
-      <div className="grid gap-8 pb-20 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
-        {[1, 2, 3, 4].map((i) => (
-          <div key={i} className="flex flex-col gap-3">
-            <Skeleton className="aspect-square" />
-            <div className="flex flex-col gap-1">
-              <Skeleton className="h-3 w-1/2" />
-              <Skeleton className="w-3/4" />
-            </div>
+    <div className="grid gap-8 pb-20 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
+      {[1, 2, 3, 4].map((i) => (
+        <div key={i} className="flex flex-col gap-3">
+          <Skeleton className="aspect-square" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-3 w-1/2" />
+            <Skeleton className="w-3/4" />
           </div>
-        ))}
-      </div>
-    </section>
+        </div>
+      ))}
+    </div>
   );
 }
 
+/**
+ * The frame of the products listing, shared by /shop and by a PRODUCTLIST page.
+ *
+ * The page's own body sits *outside* the boundaries on purpose. It is already
+ * in hand and costs no request, so putting it under the Suspense would hide
+ * readable content behind the grid's skeleton and shift the layout when it
+ * resolved, and putting it under the ErrorBoundary would delete an author's
+ * prose because an unrelated fetch failed.
+ */
 export function ProductsListSection({
-  locale,
   currentPage,
   basePath,
   searchParams,
   children,
 }: {
-  locale: string;
   currentPage: number;
   basePath: string;
   searchParams?: SearchParams;
   children?: React.ReactNode;
 }) {
   return (
-    <ErrorBoundary fallback={<ProductsListError />}>
-      <Suspense fallback={<ProductsListSkeleton />}>
-        <ProductsListContent
-          locale={locale}
-          currentPage={currentPage}
-          basePath={basePath}
-          searchParams={searchParams}
-        >
-          {children}
-        </ProductsListContent>
-      </Suspense>
-    </ErrorBoundary>
+    <section className="py-20">
+      {children ? <div className="pb-20">{children}</div> : null}
+      <ErrorBoundary fallback={<ProductsListError />}>
+        <Suspense fallback={<ProductsListSkeleton />}>
+          <ProductsListContent
+            currentPage={currentPage}
+            basePath={basePath}
+            searchParams={searchParams}
+          />
+        </Suspense>
+      </ErrorBoundary>
+    </section>
   );
 }

--- a/src/components/ShopPage/ProductsListSection.tsx
+++ b/src/components/ShopPage/ProductsListSection.tsx
@@ -40,7 +40,6 @@ export function ProductsListSection({
 }: {
   locale: string;
   currentPage: number;
-  /** What the pager pages against. See {@link ProductsListContent}. */
   basePath: string;
 }) {
   return (

--- a/src/components/ShopPage/ProductsListSection.tsx
+++ b/src/components/ShopPage/ProductsListSection.tsx
@@ -16,7 +16,7 @@ function ProductsListError() {
 
 function ProductsListSkeleton() {
   return (
-    <div className="grid gap-8 pb-20 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
+    <div className="grid gap-8 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
       {[1, 2, 3, 4].map((i) => (
         <div key={i} className="flex flex-col gap-3">
           <Skeleton className="aspect-square" />
@@ -31,37 +31,33 @@ function ProductsListSkeleton() {
 }
 
 /**
- * The frame of the products listing, shared by /shop and by a PRODUCTLIST page.
+ * The products listing /shop draws: the grid, its pager, and the boundaries
+ * they need.
  *
- * The page's own body sits *outside* the boundaries on purpose. It is already
- * in hand and costs no request, so putting it under the Suspense would hide
- * readable content behind the grid's skeleton and shift the layout when it
- * resolved, and putting it under the ErrorBoundary would delete an author's
- * prose because an unrelated fetch failed.
+ * This is the component a page gets from a product listing block in its body,
+ * which is why it takes no page content of its own and no frame — `ProductsLayout`
+ * is the frame, and the route composes the two. A PRODUCTLIST page renders that
+ * same layout around its body instead, and never reaches this.
  */
 export function ProductsListSection({
   currentPage,
   basePath,
   searchParams,
-  children,
 }: {
   currentPage: number;
+  /** Path the pager builds hrefs against; only the route knows it. */
   basePath: string;
   searchParams?: SearchParams;
-  children?: React.ReactNode;
 }) {
   return (
-    <section className="py-20">
-      {children ? <div className="pb-20">{children}</div> : null}
-      <ErrorBoundary fallback={<ProductsListError />}>
-        <Suspense fallback={<ProductsListSkeleton />}>
-          <ProductsListContent
-            currentPage={currentPage}
-            basePath={basePath}
-            searchParams={searchParams}
-          />
-        </Suspense>
-      </ErrorBoundary>
-    </section>
+    <ErrorBoundary fallback={<ProductsListError />}>
+      <Suspense fallback={<ProductsListSkeleton />}>
+        <ProductsListContent
+          currentPage={currentPage}
+          basePath={basePath}
+          searchParams={searchParams}
+        />
+      </Suspense>
+    </ErrorBoundary>
   );
 }

--- a/src/components/ShopPage/ProductsListSection.tsx
+++ b/src/components/ShopPage/ProductsListSection.tsx
@@ -14,7 +14,12 @@ function ProductsListError() {
   );
 }
 
-function ProductsListSkeleton() {
+/**
+ * Exported so /shop's route-level `loading.tsx` draws the same thing this
+ * Suspense fallback does — two copies drifted by a padding class is what the
+ * route transition and the fallback disagreeing on height looks like.
+ */
+export function ProductsListSkeleton() {
   return (
     <div className="grid gap-8 sm:max-w-full lg:grid-cols-2 xl:grid-cols-4">
       {[1, 2, 3, 4].map((i) => (

--- a/src/components/ShopPage/index.ts
+++ b/src/components/ShopPage/index.ts
@@ -1,2 +1,5 @@
 export { ProductsLayout } from "./ProductsLayout";
-export { ProductsListSection } from "./ProductsListSection";
+export {
+  ProductsListSection,
+  ProductsListSkeleton,
+} from "./ProductsListSection";

--- a/src/components/ShopPage/index.ts
+++ b/src/components/ShopPage/index.ts
@@ -1,1 +1,2 @@
+export { ProductsLayout } from "./ProductsLayout";
 export { ProductsListSection } from "./ProductsListSection";

--- a/src/components/utils/pageContent.test.ts
+++ b/src/components/utils/pageContent.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { hasRenderableContent } from "./pageContent";
+
+const localized = (fields: {
+  content?: string | null;
+  contentJSON?: { [key: string]: unknown } | null;
+}) => ({ siteId: "s1", locale: "en", ...fields });
+
+describe("hasRenderableContent", () => {
+  it("is false without localized content", () => {
+    expect(hasRenderableContent(undefined)).toBe(false);
+  });
+
+  it("is true for a markdown body", () => {
+    expect(hasRenderableContent(localized({ content: "## Notes" }))).toBe(true);
+  });
+
+  it.each([
+    ["an empty markdown body", ""],
+    ["a whitespace-only markdown body", "   \n "],
+  ])("is false for %s", (_label, content) => {
+    expect(hasRenderableContent(localized({ content }))).toBe(false);
+  });
+
+  it("is true for a doc with nodes", () => {
+    expect(
+      hasRenderableContent(
+        localized({
+          contentJSON: {
+            type: "doc",
+            content: [
+              { type: "paragraph", content: [{ type: "text", text: "Hi" }] },
+            ],
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  // The editor saves a doc either way, so the guard reads the nodes, not the key.
+  it.each([
+    ["no nodes", { type: "doc", content: [] }],
+    [
+      "one emptied paragraph",
+      { type: "doc", content: [{ type: "paragraph" }] },
+    ],
+    // Also the shape a doc the editor left serialized presents.
+    ["no node array", { type: "doc" }],
+  ])("is false for a doc with %s", (_label, contentJSON) => {
+    expect(hasRenderableContent(localized({ contentJSON }))).toBe(false);
+  });
+
+  // A node the reader can see, even with no text of its own, is content.
+  it("is true for a doc holding only an image", () => {
+    expect(
+      hasRenderableContent(
+        localized({
+          contentJSON: { type: "doc", content: [{ type: "image" }] },
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/components/utils/pageContent.test.ts
+++ b/src/components/utils/pageContent.test.ts
@@ -51,6 +51,33 @@ describe("hasRenderableContent", () => {
     expect(hasRenderableContent(localized({ contentJSON }))).toBe(false);
   });
 
+  /**
+   * The fields disagree, and the renderer's answer is the one that counts:
+   * `VenueContent` draws `contentJSON` whenever it is present and only reads
+   * the markdown when it is not. A record whose editor doc was cleared while a
+   * stale markdown mirror stayed behind therefore renders nothing, so judging
+   * the markdown first would space the listing around an empty body.
+   */
+  it("is false for an emptied doc still carrying stale markdown", () => {
+    expect(
+      hasRenderableContent(
+        localized({
+          content: "## Notes from a previous edit",
+          contentJSON: { type: "doc", content: [{ type: "paragraph" }] },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  // And the mirror is still what a body with no doc at all is judged by.
+  it("is true for markdown with no doc beside it", () => {
+    expect(
+      hasRenderableContent(
+        localized({ content: "## Notes", contentJSON: null }),
+      ),
+    ).toBe(true);
+  });
+
   // A node the reader can see, even with no text of its own, is content.
   it("is true for a doc holding only an image", () => {
     expect(

--- a/src/components/utils/pageContent.ts
+++ b/src/components/utils/pageContent.ts
@@ -1,0 +1,32 @@
+import type { LocalizedContent } from "@venuecms/sdk-next";
+
+/**
+ * Whether a body would put anything on screen.
+ *
+ * `contentJSON` is truthy even for a cleared editor, which saves a doc holding
+ * one empty paragraph, so a caller guarding on the field alone spaces around
+ * nothing. Only a paragraph is judged by its children: an image or an embed
+ * carries no text and is still content.
+ */
+export const hasRenderableContent = (content?: LocalizedContent): boolean => {
+  if (content?.content?.trim()) {
+    return true;
+  }
+
+  const nodes = content?.contentJSON?.content;
+
+  if (!Array.isArray(nodes)) {
+    return false;
+  }
+
+  return nodes.some((node) => {
+    const { type, content: children } = (node ?? {}) as {
+      type?: string;
+      content?: unknown;
+    };
+
+    return (
+      type !== "paragraph" || (Array.isArray(children) && children.length > 0)
+    );
+  });
+};

--- a/src/components/utils/pageContent.ts
+++ b/src/components/utils/pageContent.ts
@@ -7,13 +7,20 @@ import type { LocalizedContent } from "@venuecms/sdk-next";
  * one empty paragraph, so a caller guarding on the field alone spaces around
  * nothing. Only a paragraph is judged by its children: an image or an embed
  * carries no text and is still content.
+ *
+ * The two fields are judged in the renderer's own order rather than the other
+ * way round. `VenueContent` draws `contentJSON` whenever it is present and only
+ * falls back to the `content` markdown when it is not, so a record still
+ * carrying a stale markdown mirror under an emptied editor doc renders nothing.
+ * Reading the markdown first would call that body renderable on the strength of
+ * a field the renderer is never going to reach.
  */
 export const hasRenderableContent = (content?: LocalizedContent): boolean => {
-  if (content?.content?.trim()) {
-    return true;
+  if (!content?.contentJSON) {
+    return Boolean(content?.content?.trim());
   }
 
-  const nodes = content?.contentJSON?.content;
+  const nodes = content.contentJSON.content;
 
   if (!Array.isArray(nodes)) {
     return false;

--- a/src/components/utils/pageLayout.test.ts
+++ b/src/components/utils/pageLayout.test.ts
@@ -8,15 +8,12 @@ describe("resolvePageListingLayout", () => {
     expect(resolvePageListingLayout("NEWSLIST")).toBe("news");
     expect(resolvePageListingLayout("EVENTLIST")).toBe("events");
     expect(resolvePageListingLayout("PRODUCTLIST")).toBe("products");
+    expect(resolvePageListingLayout("PROFILELIST")).toBe("profiles");
   });
 
   it("leaves an ordinary page on the page layout", () => {
     expect(resolvePageListingLayout("CONTENT")).toBeNull();
     expect(resolvePageListingLayout("LINK")).toBeNull();
-  });
-
-  it("leaves a profile listing on the page layout, having no index for it", () => {
-    expect(resolvePageListingLayout("PROFILELIST")).toBeNull();
   });
 
   it("leaves a page type this template has never heard of on the page layout", () => {

--- a/src/components/utils/pageLayout.test.ts
+++ b/src/components/utils/pageLayout.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { resolvePageListingLayout } from "./pageLayout";
+
+describe("resolvePageListingLayout", () => {
+  it("maps each listing page type this template draws to its listing", () => {
+    expect(resolvePageListingLayout("NEWS")).toBe("news");
+    expect(resolvePageListingLayout("NEWSLIST")).toBe("news");
+    expect(resolvePageListingLayout("EVENTLIST")).toBe("events");
+    expect(resolvePageListingLayout("PRODUCTLIST")).toBe("products");
+  });
+
+  it("leaves an ordinary page on the page layout", () => {
+    expect(resolvePageListingLayout("CONTENT")).toBeNull();
+    expect(resolvePageListingLayout("LINK")).toBeNull();
+  });
+
+  it("leaves a profile listing on the page layout, having no index for it", () => {
+    // Deliberate, not an oversight: this template has no profiles index — only
+    // /artists/<slug> — so a page typed PROFILELIST has nothing to stand in
+    // for. It renders its own content, which is the better of the two failures.
+    expect(resolvePageListingLayout("PROFILELIST")).toBeNull();
+  });
+
+  it("leaves a page type this template has never heard of on the page layout", () => {
+    // A page type added to the CMS after this template shipped arrives here as
+    // a plain string. Falling back to the page layout is what keeps such a page
+    // rendering its own content rather than crashing or blanking.
+    expect(resolvePageListingLayout("SOMETHING_NEW")).toBeNull();
+  });
+});

--- a/src/components/utils/pageLayout.test.ts
+++ b/src/components/utils/pageLayout.test.ts
@@ -16,16 +16,10 @@ describe("resolvePageListingLayout", () => {
   });
 
   it("leaves a profile listing on the page layout, having no index for it", () => {
-    // Deliberate, not an oversight: this template has no profiles index — only
-    // /artists/<slug> — so a page typed PROFILELIST has nothing to stand in
-    // for. It renders its own content, which is the better of the two failures.
     expect(resolvePageListingLayout("PROFILELIST")).toBeNull();
   });
 
   it("leaves a page type this template has never heard of on the page layout", () => {
-    // A page type added to the CMS after this template shipped arrives here as
-    // a plain string. Falling back to the page layout is what keeps such a page
-    // rendering its own content rather than crashing or blanking.
     expect(resolvePageListingLayout("SOMETHING_NEW")).toBeNull();
   });
 });

--- a/src/components/utils/pageLayout.ts
+++ b/src/components/utils/pageLayout.ts
@@ -1,0 +1,35 @@
+/**
+ * Which listing, if any, a page's type stands in for.
+ *
+ * A page can be marked in the CMS as the site's news / events / products index.
+ * Such a page renders that listing rather than its own content, so an author
+ * can put the index anywhere in the page tree — and so the listing looks the
+ * same whether a reader arrives at `/events` or at a page slugged something
+ * else entirely.
+ */
+export type PageListingLayout = "news" | "events" | "products";
+
+/**
+ * Keyed by the CMS's `PAGE_TYPE`, and typed against `string` rather than the
+ * SDK's `Page["type"]` on purpose: that union is generated from the API schema
+ * and still stops at `NEWSLIST`, so naming the list types here would not
+ * compile. A lookup is also what makes the unknown case free — a page type
+ * added to the CMS after this template shipped falls through to the page layout
+ * instead of blanking the page.
+ *
+ * `PROFILELIST` is absent for a different reason: the platform has the type,
+ * but this template has no profiles index to point it at — profiles appear as
+ * `/artists/<slug>` and as a listing block inside content, never as a route of
+ * their own. Such a page keeps its own content until there is one.
+ */
+const LISTING_LAYOUT_BY_PAGE_TYPE: Partial<Record<string, PageListingLayout>> =
+  {
+    NEWS: "news",
+    NEWSLIST: "news",
+    EVENTLIST: "events",
+    PRODUCTLIST: "products",
+  };
+
+export const resolvePageListingLayout = (
+  type: string,
+): PageListingLayout | null => LISTING_LAYOUT_BY_PAGE_TYPE[type] ?? null;

--- a/src/components/utils/pageLayout.ts
+++ b/src/components/utils/pageLayout.ts
@@ -1,27 +1,7 @@
-/**
- * Which listing, if any, a page's type stands in for.
- *
- * A page can be marked in the CMS as the site's news / events / products index.
- * Such a page renders that listing rather than its own content, so an author
- * can put the index anywhere in the page tree — and so the listing looks the
- * same whether a reader arrives at `/events` or at a page slugged something
- * else entirely.
- */
 export type PageListingLayout = "news" | "events" | "products";
 
-/**
- * Keyed by the CMS's `PAGE_TYPE`, and typed against `string` rather than the
- * SDK's `Page["type"]` on purpose: that union is generated from the API schema
- * and still stops at `NEWSLIST`, so naming the list types here would not
- * compile. A lookup is also what makes the unknown case free — a page type
- * added to the CMS after this template shipped falls through to the page layout
- * instead of blanking the page.
- *
- * `PROFILELIST` is absent for a different reason: the platform has the type,
- * but this template has no profiles index to point it at — profiles appear as
- * `/artists/<slug>` and as a listing block inside content, never as a route of
- * their own. Such a page keeps its own content until there is one.
- */
+// Keyed by PAGE_TYPE as `string`: the SDK's Page["type"] union stops at NEWSLIST.
+// PROFILELIST omitted — this template has no profiles index to stand in for.
 const LISTING_LAYOUT_BY_PAGE_TYPE: Partial<Record<string, PageListingLayout>> =
   {
     NEWS: "news",

--- a/src/components/utils/pageLayout.ts
+++ b/src/components/utils/pageLayout.ts
@@ -1,13 +1,13 @@
-export type PageListingLayout = "news" | "events" | "products";
+export type PageListingLayout = "news" | "events" | "products" | "profiles";
 
 // Keyed by PAGE_TYPE as `string`: the SDK's Page["type"] union stops at NEWSLIST.
-// PROFILELIST omitted — this template has no profiles index to stand in for.
 const LISTING_LAYOUT_BY_PAGE_TYPE: Partial<Record<string, PageListingLayout>> =
   {
     NEWS: "news",
     NEWSLIST: "news",
     EVENTLIST: "events",
     PRODUCTLIST: "products",
+    PROFILELIST: "profiles",
   };
 
 export const resolvePageListingLayout = (

--- a/src/components/utils/searchParams.test.ts
+++ b/src/components/utils/searchParams.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPageHref } from "./searchParams";
+
+describe("buildPageHref", () => {
+  it("pages against the path it was given", () => {
+    expect(buildPageHref("/p/merch", {}, 2)).toBe("/p/merch?page=2");
+  });
+
+  it("replaces the page it was handed rather than repeating it", () => {
+    expect(buildPageHref("/p/merch", { page: "1" }, 2)).toBe("/p/merch?page=2");
+  });
+
+  // Without this a listing block in the page's body snaps back to page 0.
+  it("carries a listing block's own param through", () => {
+    expect(buildPageHref("/p/merch", { evt_9k3z1: "3" }, 1)).toBe(
+      "/p/merch?evt_9k3z1=3&page=1",
+    );
+  });
+
+  it("keeps every value of a repeated param", () => {
+    expect(buildPageHref("/archive", { tag: ["a", "b"] }, 1)).toBe(
+      "/archive?tag=a&tag=b&page=1",
+    );
+  });
+
+  it("drops a param the URL left empty", () => {
+    expect(buildPageHref("/archive", { tag: undefined }, 1)).toBe(
+      "/archive?page=1",
+    );
+  });
+});

--- a/src/components/utils/searchParams.test.ts
+++ b/src/components/utils/searchParams.test.ts
@@ -1,6 +1,34 @@
+import { MAX_PAGE } from "@venuecms/sdk-next";
 import { describe, expect, it } from "vitest";
 
-import { buildPageHref } from "./searchParams";
+import { buildPageHref, readPage } from "./searchParams";
+
+describe("readPage", () => {
+  it("reads the page the URL names", () => {
+    expect(readPage({ page: "3" })).toBe(3);
+  });
+
+  it("starts at the first page when the URL names none", () => {
+    expect(readPage({})).toBe(0);
+  });
+
+  it("takes the first of a repeated param, as a route would", () => {
+    expect(readPage({ page: ["1", "2"] })).toBe(1);
+  });
+
+  // Digits only. Number() would read "1e3" as the deepest offset the endpoint
+  // will scan and "-2" as a negative one; parseInt would take "12abc" for 12.
+  it.each(["not-a-page", "-2", "3abc", "2.5", "1e3", "", " 1"])(
+    "starts at the first page rather than sending %j to the endpoint",
+    (page) => {
+      expect(readPage({ page })).toBe(0);
+    },
+  );
+
+  it("clamps a hand-edited page to the deepest the endpoint will scan", () => {
+    expect(readPage({ page: String(MAX_PAGE + 5000) })).toBe(MAX_PAGE);
+  });
+});
 
 describe("buildPageHref", () => {
   it("pages against the path it was given", () => {

--- a/src/components/utils/searchParams.ts
+++ b/src/components/utils/searchParams.ts
@@ -1,4 +1,26 @@
-import type { SearchParams } from "@venuecms/sdk-next";
+import { MAX_PAGE, type SearchParams } from "@venuecms/sdk-next";
+
+/**
+ * The page a URL is asking for: the read half of the same concern
+ * `buildPageHref` writes, kept beside it so a pager's two ends cannot drift.
+ *
+ * Anything that is not a run of digits starts at the first page rather than
+ * reaching the endpoint. `Number()` would read "1e3" as the deepest offset the
+ * endpoint will scan and "-2" as a negative one; `parseInt` would take "12abc"
+ * for 12.
+ */
+export const readPage = (searchParams: SearchParams): number => {
+  const raw = searchParams.page;
+  const value = Array.isArray(raw) ? raw[0] : raw;
+
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    return 0;
+  }
+
+  // Clamped rather than passed on: a hand-edited page deeper than the endpoint
+  // will scan is a request it would refuse anyway.
+  return Math.min(Number(value), MAX_PAGE);
+};
 
 /**
  * A route pager's href, carrying every other param through.

--- a/src/components/utils/searchParams.ts
+++ b/src/components/utils/searchParams.ts
@@ -1,0 +1,29 @@
+import type { SearchParams } from "@venuecms/sdk-next";
+
+/**
+ * A route pager's href, carrying every other param through.
+ *
+ * A listing block in the page's body owns a param of its own, so a pager that
+ * wrote `?page=N` alone would snap that block back to its first page.
+ */
+export const buildPageHref = (
+  basePath: string,
+  searchParams: SearchParams,
+  page: number,
+): string => {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (key === "page" || value === undefined) {
+      continue;
+    }
+
+    for (const entry of Array.isArray(value) ? value : [value]) {
+      params.append(key, entry);
+    }
+  }
+
+  params.set("page", String(page));
+
+  return `${basePath}?${params.toString()}`;
+};

--- a/test/stubs/next-navigation.ts
+++ b/test/stubs/next-navigation.ts
@@ -14,15 +14,7 @@ export const useRouter = () => ({
 
 export const usePathname = () => "/";
 
-/**
- * Next's not-found signal.
- *
- * A route or a server component reaches for this when a read comes back empty,
- * so a test that exercises one has to be able to tell "rendered nothing" from
- * "bailed out". Real `notFound()` throws a framework error the router catches;
- * throwing a recognisable one here keeps that distinction without pulling the
- * router in.
- */
+/** Recognisable throw so a test can tell a bailout from an empty render. */
 export const notFound = (): never => {
   throw new Error("NEXT_NOT_FOUND");
 };

--- a/test/stubs/next-navigation.ts
+++ b/test/stubs/next-navigation.ts
@@ -1,6 +1,6 @@
 /**
  * next-intl's client navigation reaches for `next/navigation`, which pnpm does
- * not link into its isolated tree. Only the two hooks it imports are needed —
+ * not link into its isolated tree. Only the hooks it imports are needed —
  * nothing under test navigates.
  */
 export const useRouter = () => ({
@@ -13,3 +13,16 @@ export const useRouter = () => ({
 });
 
 export const usePathname = () => "/";
+
+/**
+ * Next's not-found signal.
+ *
+ * A route or a server component reaches for this when a read comes back empty,
+ * so a test that exercises one has to be able to tell "rendered nothing" from
+ * "bailed out". Real `notFound()` throws a framework error the router catches;
+ * throwing a recognisable one here keeps that distinction without pulling the
+ * router in.
+ */
+export const notFound = (): never => {
+  throw new Error("NEXT_NOT_FOUND");
+};


### PR DESCRIPTION
A page typed `EVENTLIST`, `PRODUCTLIST`, `PROFILELIST`, `NEWS` or `NEWSLIST` now renders the matching listing layout instead of the generic page layout, drawn by the same views `/events`, `/shop` and `/archive` already use.

For products the layout is now a frame and nothing else. `/shop` composes that frame with the listing itself, exactly as a page ends up with a products block inside it, and both draw the shared `ProductsList` — four leading products in a four-column track, the rest in a six-column one. Previously a `PRODUCTLIST` page drew the author's block *and* fetched a second grid under it, and the block used a plainer grid that looked nothing like `/shop`.

So a block can fill the width, a page body scopes its readable measure to the prose rather than the whole body. That applies to ordinary pages and news articles too, which would otherwise crush the shop's six-column track into a 42rem column.

This folds in VEN-521, previously PR #71, which is now closed — one PR in place of the stack, as asked.

Two things worth a reviewer's attention. A published `PROFILELIST` page previously fell through to the generic layout and drew its *curated* artists, its image and its page tree; it now draws the site-wide roster, matching template-liminal. And a `PRODUCTLIST` page with no products block in its body now draws nothing rather than a grid — that is the architecture, but it is a behaviour change for pages authored before listing blocks existed.

`/shop`'s pager arithmetic did have to change: dropping the old gate exposed a fallback of 100 pages behind a falsy `count`, so an empty shop offered ninety-nine live page links. It now counts off what the endpoint answered. That overlaps VEN-514 (#69).

`events` and `profiles` still render their own records *and* the page body, so they keep the duplicate-listing behaviour products just lost — deliberately left alone pending a call on whether to extend the same treatment.

No `VENUE_API_KEY` in this environment, so this was not driven in a browser: verified by `pnpm typecheck` and 172 passing vitest tests, up from 105 on `dev`. `pnpm build` fails identically here and on the parent commit (prerender of `/_not-found`), so it is not a regression from this branch.